### PR TITLE
Feature/bt planning integration

### DIFF
--- a/ami_agents/agents/interaction_solver/interaction_solver_agent.py
+++ b/ami_agents/agents/interaction_solver/interaction_solver_agent.py
@@ -30,65 +30,13 @@ from ...shared.utils.spade_rpc import rpc_call, RpcTimeoutError, send_via_router
 from ...shared.utils.demo_log import demo
 from ...shared.models.plan import BehaviorTreePlan, NodeTemplate, Plan
 from ...shared.protocols.llm_protocol import IPlanGenerator
+from ...bt_planning.planning.bt_planner import AsyncBTPlanner
+from ...bt_planning.signifier_bridge import build_bt_from_signifiers
+from ...shared.community.community_client import CommunitySignifierClient
 
 logger = logging.getLogger("InteractionSolver")
 
-# System prompt for strict multi-intent JSON-Plan 1.2 planning.
-INTERACTION_SOLVER_SYSTEM_PROMPT = """
-You are Interaction-Solver. You receive a list of intents and must return an executable plan in JSON-Plan 1.2 format.
-
-You will be given environment context (affordances + state) in the user message. You MUST NOT invent actions, URIs, or methods.
-
-MULTI-INTENT RULE (STRICT):
-- The plan must satisfy ALL provided intents.
-- Each step.intent MUST match exactly one of the provided intents (do not rephrase, change case, or combine intents).        
-- If you cannot satisfy all intents using the provided affordances, return a strict failure JSON:
-  {"plan_version":"1.2","error":"infeasible","detail":"...","steps":[]}   
-
-PLAN FORMAT  JSON-Plan 1.2
----------------------------
-{
-  "plan_version": "1.2",
-  "steps": [
-    {
-      "step_id": 1,
-      "intent": "<exact intent this step fulfills from the list of intents>",
-      "artifact_uri": "<full URI>",
-      "affordance_uri": "<full URI>",
-      "action_name": "<td:name>",
-      "method": "<HTTP verb>",
-      "target": "<hctl:hasTarget URI>",
-      "content_type": "application/json",
-      "payload": { },
-      "reasons": [
-        {
-          "property":  "<property satisfied>",
-          "direction": "<increase|decrease|set>",
-            "evidence": [
-              {
-                "artifact":  "<sensor-or-artifact URI>",
-                "property":  "<attribute name>",
-                "operator":  "<lessThan|lessEqual|greaterThan|greaterEqual|equals>",
-                "threshold": "<number|string>",
-                "reading":   "<number|string>"
-              }
-            ],
-          "why": "One or two sentences explaining why this step is needed."
-        }
-      ]
-    }
-  ]
-}
-
-Rules:
-  - Always set plan_version to "1.2".
-  - Every step must include at least one reasons entry with at least one evidence item.
-  - Use complete, non-fabricated URIs. If absent, clearly indicate placeholders.
-  - Payload values MUST be valid JSON types: use numbers for numeric values (not quoted strings), booleans for true/false.
-  - When setting a parameter, the payload keys MUST match the affordance payload schema exactly (including casing).
-  - Use ASCII only in all string fields (no curly quotes, no em/en dashes, no ellipsis character).
-  - Output only the JSON plan (no additional prose). If no plan is feasible, return a JSON with plan_version=1.2, error, detail, steps=[].
-"""
+# Planning prompt is now in ami_agents.bt_planning.planning.prompts (BT JSON IR format).
 
 DEFAULT_TIMEOUT = 10
 
@@ -179,6 +127,18 @@ class InteractionSolverAgent(Agent, IAgent):
         if self.reasoning_effort is None and str(self.model).startswith("o") and "openai.com" in self.base_url:
             self.reasoning_effort = "high"
         self.llm_client = AsyncOpenAI(api_key=api_key, base_url=base_url, timeout=timeout)
+
+        # BT planner: generates JSON IR behavior trees via LLM tool calls
+        self.bt_planner = AsyncBTPlanner(max_attempts=3)
+
+        # Community signifier client (cross-environment sharing)
+        community_cfg = (self.config.get("planning", {}) or {}).get("community", {}) or {}
+        community_url = community_cfg.get("api_url") or os.getenv("COMMUNITY_API_URL")
+        self.community_enabled = community_cfg.get("enabled", bool(community_url))
+        self.community_client: Optional[CommunitySignifierClient] = None
+        if self.community_enabled and community_url:
+            community_timeout = float(community_cfg.get("timeout", 5.0))
+            self.community_client = CommunitySignifierClient(api_url=community_url, timeout=community_timeout)
 
     def mark_environment_ready(self, *, sender_jid: Optional[str] = None, payload: Optional[Dict[str, Any]] = None) -> None:
         self.environment_ready = True
@@ -355,24 +315,31 @@ class InteractionSolverAgent(Agent, IAgent):
 
     async def _generate_plan(self, intents: List[str], workspace_id: Optional[str] = None) -> str:
         """
-        Gather context programmatically (affordances + state) and ask the LLM once.
-        If the LLM call fails or returns non-JSON, wrap a diagnostic JSON.
+        Gather context programmatically (affordances + state) and generate a BT JSON IR plan.
+
+        Returns a JSON string with the plan in behavior tree format:
+        {
+            "plan_type": "behavior_tree",
+            "tree": { ... },            # JSON IR behavior tree spec (or None)
+            "explanation": "...",        # LLM's explanation
+            "intents": ["..."],          # Input intents
+            "impossible": false,         # True if the goal is infeasible
+            "signifier_reuse": false,    # True if built from signifiers (no LLM)
+        }
         """
         intents = [str(i).strip() for i in (intents or []) if str(i).strip()]
         if not intents:
             return json.dumps(
-                {"plan_version": "1.2", "error": "missing_intents", "detail": "No intents provided.", "steps": []},
+                {"plan_type": "behavior_tree", "error": "missing_intents", "detail": "No intents provided.",
+                 "tree": None, "intents": []},
                 indent=2,
             )
 
         # Fast-path: if there is a suitable signifier match for every intent, reuse it to build
-        # a plan directly, without querying EnvExplorer for capabilities/state and without calling the LLM.
+        # a BT directly, without querying EnvExplorer for capabilities/state and without calling the LLM.
         reused_plan = await self._try_build_plan_from_signifiers(intents, workspace_id=workspace_id)
         if reused_plan is not None:
-            logger.info(
-                demo("Plan recovered from signifiers (no EnvExplorer context queries, no LLM): steps=%d"),
-                len(reused_plan.get("steps") or []),
-            )
+            logger.info(demo("BT recovered from signifiers (no EnvExplorer context queries, no LLM)"))
             return json.dumps(reused_plan, indent=2)
 
         try:
@@ -381,146 +348,64 @@ class InteractionSolverAgent(Agent, IAgent):
             logger.warning(f"Context gathering failed: {e}")
             return json.dumps(
                 {
-                    "plan_version": "1.2",
+                    "plan_type": "behavior_tree",
                     "error": "context_gathering_failed",
                     "detail": str(e),
-                    "steps": [],
+                    "tree": None,
+                    "intents": intents,
                 },
                 indent=2,
             )
 
-        prompt_messages = self._build_planning_prompt(intents, context, workspace_id=workspace_id)
-
-        def _extract_json_text(raw: str) -> str:
-            """
-            Best-effort extraction of a JSON object/array from LLM output.
-            Handles common cases like markdown code fences.
-            """
-            if not raw:
-                return raw
-            s = raw.strip()
-
-            # Strip markdown fences: ```json ... ``` or ``` ... ```
-            if s.startswith("```"):
-                # remove first fence line
-                first_nl = s.find("\n")
-                if first_nl != -1:
-                    s = s[first_nl + 1 :]
-                # remove trailing fence
-                if s.rstrip().endswith("```"):
-                    s = s.rstrip()
-                    s = s[: -3]
-                s = s.strip()
-
-            # If still has surrounding prose, try to isolate the first JSON blob.
-            # Prefer {...} but allow [...] too.
-            obj_start = s.find("{")
-            arr_start = s.find("[")
-            if obj_start == -1 and arr_start == -1:
-                return s
-
-            if obj_start == -1 or (arr_start != -1 and arr_start < obj_start):
-                start = arr_start
-                end = s.rfind("]")
-            else:
-                start = obj_start
-                end = s.rfind("}")
-
-            if start != -1 and end != -1 and end > start:
-                return s[start : end + 1].strip()
-            return s
-
+        # Generate BT using AsyncBTPlanner (LLM tool call with validation retries)
         try:
-            completion_kwargs: Dict[str, Any] = {
-                "model": self.model,
-                "messages": prompt_messages,
-            }
-            if not str(self.model).startswith("o"):
-                completion_kwargs["temperature"] = self.temperature
-            if self.max_completion_tokens is not None:
-                completion_kwargs["max_completion_tokens"] = self.max_completion_tokens
-            elif self.max_tokens is not None:
-                completion_kwargs["max_tokens"] = self.max_tokens
-            if self.reasoning_effort and str(self.model).startswith("o"):
-                completion_kwargs["reasoning_effort"] = self.reasoning_effort
-
-            completion = await self.llm_client.chat.completions.create(**completion_kwargs)
-            content = completion.choices[0].message.content or ""
-            content = content.strip()
-            json_text = _extract_json_text(content)
-
-            # Try to parse JSON; if invalid, wrap as diagnostic
-            try:
-                parsed = json.loads(json_text)
-                # Enforce strict contract: must be a JSON object with plan_version=1.2 and steps list
-                if not isinstance(parsed, dict):
-                    raise ValueError("Plan response is not a JSON object")
-
-                if str(parsed.get("plan_version")) != "1.2":
-                    return json.dumps(
-                        {"plan_version": "1.2", "error": "invalid_plan_version", "detail": "Expected plan_version=1.2", "steps": []},
-                        indent=2,
-                    )
-
-                steps = parsed.get("steps")
-                if not isinstance(steps, list):
-                    return json.dumps(
-                        {"plan_version": "1.2", "error": "invalid_plan_format", "detail": "Missing steps list", "steps": []},
-                        indent=2,
-                    )
-
-                if len(steps) == 0:
-                    # already strict-failure shape is acceptable; ensure error present if empty
-                    if "error" not in parsed:
-                        parsed["error"] = "infeasible"
-                        parsed["detail"] = parsed.get("detail") or "No feasible plan for all intents."
-                    return json.dumps(parsed, indent=2)
-
-                # Coverage check: each input intent must appear at least once in step.intent
-                step_intents = {str(s.get("intent")) for s in steps if isinstance(s, dict) and s.get("intent") is not None}
-                missing = [i for i in intents if i not in step_intents]
-                if missing:
-                    return json.dumps(
-                        {
-                            "plan_version": "1.2",
-                            "error": "infeasible",
-                            "detail": f"Plan did not cover all intents. Missing: {missing}",
-                            "steps": [],
-                        },
-                        indent=2,
-                    )
-
-                return json.dumps(parsed, indent=2)
-            except Exception:
-                return json.dumps(
-                    {
-                        "plan_version": "1.2",
-                        "error": "non_json_response",
-                        "raw_response": content,
-                        "steps": [],
-                    },
-                    indent=2,
-                )
+            result = await self.bt_planner.generate_bt(
+                intents=intents,
+                affordances=context.get("affordances", []),
+                state=context.get("state"),
+                signifier_hints=context.get("signifier_matches"),
+                client=self.llm_client,
+                model=self.model,
+                temperature=self.temperature if not str(self.model).startswith("o") else None,
+                reasoning_effort=self.reasoning_effort,
+                max_completion_tokens=self.max_completion_tokens,
+            )
         except Exception as e:
-            logger.warning(f"LLM plan generation failed, returning error JSON: {e}")
-            fallback = {
-                "plan_version": "1.2",
-                "error": "plan_generation_failed",
-                "detail": str(e),
-                "steps": [],
-            }
-            return json.dumps(fallback, indent=2)
+            logger.warning(f"BT generation failed: {e}")
+            return json.dumps(
+                {
+                    "plan_type": "behavior_tree",
+                    "error": "plan_generation_failed",
+                    "detail": str(e),
+                    "tree": None,
+                    "intents": intents,
+                },
+                indent=2,
+            )
+
+        # Wrap result in standard format
+        output: Dict[str, Any] = {
+            "plan_type": "behavior_tree",
+            "tree": result.get("tree") or None,
+            "explanation": result.get("explanation", ""),
+            "intents": intents,
+        }
+
+        if result.get("impossible"):
+            output["impossible"] = True
+
+        return json.dumps(output, indent=2)
 
     async def _try_build_plan_from_signifiers(
         self, intents: List[str], workspace_id: Optional[str] = None
     ) -> Optional[Dict[str, Any]]:
         """
-        Try to build a JSON-Plan 1.2 directly from signifier matches.
+        Try to build a BT JSON IR directly from signifier matches (fast path).
 
         Notes:
         - We still query EnvExplorer for SIGNIFIER_MATCH_REQUEST (it hosts the embedded RD4 engine).
         - We MUST NOT query EnvExplorer for ENV_CAPABILITIES_REQUEST / ENV_STATE_REQUEST in this path.
-        - If any intent has no usable signifier match, return None.
+        - If any intent has no usable signifier match, return None (triggers normal LLM path).
         """
         try:
             signifier_matches = await self._gather_signifier_matches(intents, workspace_id=workspace_id)
@@ -530,103 +415,27 @@ class InteractionSolverAgent(Agent, IAgent):
         if not isinstance(signifier_matches, dict) or not signifier_matches:
             return None
 
-        def _pick_match(intent: str) -> Optional[Dict[str, Any]]:
-            payload = signifier_matches.get(intent)
-            if not isinstance(payload, dict):
-                return None
-            finals = payload.get("final_matches") or []
-            matches = payload.get("matches") or []
-            if not isinstance(finals, list) or not finals:
-                return None
-            if not isinstance(matches, list) or not matches:
-                return None
-
-            chosen_id = str(finals[0])
-            for m in matches:
-                if not isinstance(m, dict):
-                    continue
-                if str(m.get("signifier_id") or "") == chosen_id:
-                    return m
+        tree = build_bt_from_signifiers(signifier_matches, intents)
+        if tree is None:
             return None
 
-        steps: List[Dict[str, Any]] = []
-        for idx, intent in enumerate(intents, start=1):
-            match = _pick_match(intent)
-            if not match:
-                return None
+        # Collect signifier IDs used for traceability
+        signifier_ids: List[str] = []
+        for intent in intents:
+            match_data = signifier_matches.get(intent, {})
+            if isinstance(match_data, dict):
+                finals = match_data.get("final_matches", [])
+                if finals:
+                    signifier_ids.append(str(finals[0]))
 
-            affordance_uri = str(match.get("affordance_uri") or "").strip()
-            if not affordance_uri:
-                return None
-
-            payload_hint = match.get("payload_hint")
-            payload = payload_hint if isinstance(payload_hint, dict) else {}
-
-            signifier_id = str(match.get("signifier_id") or "").strip()
-            similarity = match.get("intent_similarity")
-
-            cached_aff = self._cached_affordance_by_id.get(affordance_uri)
-            action_name = ""
-            method = None
-            target = None
-            content_type = "application/json"
-            artifact_uri = ""
-
-            if isinstance(cached_aff, dict):
-                action_name = str(cached_aff.get("action_name") or "")
-                method = cached_aff.get("method")
-                target = cached_aff.get("target")
-                content_type = str(cached_aff.get("content_type") or "application/json")
-                artifact_uri = str(cached_aff.get("artifact_id") or "")
-
-            if not action_name:
-                action_name = affordance_uri.rstrip("/").rsplit("/", 1)[-1]
-
-            if not artifact_uri:
-                # Best-effort: derive artifact URI from the affordance URI.
-                try:
-                    prefix, rest = affordance_uri.split("/artifacts/", 1)
-                    artifact_name = rest.split("/", 1)[0]
-                    artifact_uri = f"{prefix}/artifacts/{artifact_name}#artifact"
-                except Exception:
-                    artifact_uri = ""
-
-            # If we don't have a cached affordance form, assume the affordance URI is callable.
-            if target is None:
-                target = affordance_uri
-            if method is None:
-                method = "POST"
-
-            step_meta: Dict[str, Any] = {"reused_from_signifier": True}
-            if signifier_id:
-                step_meta["used_signifier_id"] = signifier_id
-            if similarity is not None:
-                step_meta["used_signifier_similarity"] = similarity
-
-            steps.append(
-                {
-                    "step_id": idx,
-                    "intent": intent,
-                    "artifact_uri": artifact_uri,
-                    "affordance_uri": affordance_uri,
-                    "action_name": action_name,
-                    "method": method,
-                    "target": target,
-                    "content_type": content_type,
-                    "payload": payload,
-                    "metadata": step_meta,
-                    "reasons": [
-                        {
-                            "property": "reused_signifier",
-                            "direction": "set",
-                            "evidence": [],
-                            "why": "Recovered this step from a previously stored Signifier (intent/context match).",
-                        }
-                    ],
-                }
-            )
-
-        return {"plan_version": "1.2", "steps": steps}
+        return {
+            "plan_type": "behavior_tree",
+            "tree": tree,
+            "explanation": "Plan recovered from signifiers (no LLM call needed).",
+            "intents": intents,
+            "signifier_reuse": True,
+            "signifier_ids": signifier_ids,
+        }
 
     async def _gather_planning_context(self, intents: List[str], workspace_id: Optional[str] = None) -> Dict[str, Any]:
         """
@@ -748,39 +557,67 @@ class InteractionSolverAgent(Agent, IAgent):
         }
 
     async def _gather_signifier_matches(self, intents: List[str], workspace_id: Optional[str] = None) -> Dict[str, Any]:
-        """Ask EnvExplorer for signifier matches per intent (best-effort)."""
-        explorer_jid = self.target_jids.get("explorer")
-        if not explorer_jid:
-            return {}
+        """
+        Ask EnvExplorer for signifier matches per intent (best-effort).
 
+        Also queries the community signifier API (if configured) for cross-environment matches.
+        Local matches take priority; community matches supplement gaps.
+        """
         intents = [str(i).strip() for i in (intents or []) if str(i).strip()]
         if not intents:
             return {}
 
-        async def _one(intent: str) -> Dict[str, Any]:
-            raw = await self._query_env_explorer(
-                message_type=MessageType.SIGNIFIER_MATCH_REQUEST.value,
-                body={
-                    "intent": intent,
-                    **({"workspace_id": str(workspace_id)} if workspace_id else {}),
-                    "k": 5,
-                },
-                expect_type=MessageType.SIGNIFIER_MATCH_RESPONSE.value,
-            )
-            try:
-                data = json.loads(raw) if raw else {}
-                return data if isinstance(data, dict) else {}
-            except Exception:
-                return {}
+        # Query local EnvExplorer (via SPADE RPC)
+        explorer_jid = self.target_jids.get("explorer")
+        local_out: Dict[str, Any] = {}
+        if explorer_jid:
+            async def _one_local(intent: str) -> Dict[str, Any]:
+                raw = await self._query_env_explorer(
+                    message_type=MessageType.SIGNIFIER_MATCH_REQUEST.value,
+                    body={
+                        "intent": intent,
+                        **({"workspace_id": str(workspace_id)} if workspace_id else {}),
+                        "k": 5,
+                    },
+                    expect_type=MessageType.SIGNIFIER_MATCH_RESPONSE.value,
+                )
+                try:
+                    data = json.loads(raw) if raw else {}
+                    return data if isinstance(data, dict) else {}
+                except Exception:
+                    return {}
 
-        results = await asyncio.gather(*[_one(i) for i in intents], return_exceptions=True)
+            local_results = await asyncio.gather(*[_one_local(i) for i in intents], return_exceptions=True)
+            for intent, res in zip(intents, local_results):
+                if isinstance(res, Exception):
+                    local_out[intent] = {"error": "signifier_query_failed", "detail": str(res)}
+                else:
+                    local_out[intent] = res
 
-        out: Dict[str, Any] = {}
-        for intent, res in zip(intents, results):
-            if isinstance(res, Exception):
-                out[intent] = {"error": "signifier_query_failed", "detail": str(res)}
-            else:
-                out[intent] = res
+        # Query community signifier API (if configured)
+        community_out: Dict[str, Any] = {}
+        if self.community_client:
+            async def _one_community(intent: str) -> Dict[str, Any]:
+                try:
+                    data = await self.community_client.match_signifiers(intent)
+                    if data:
+                        # Tag community matches with source
+                        for m in data.get("matches", []):
+                            if isinstance(m, dict):
+                                m["source"] = "community"
+                    return data
+                except Exception:
+                    return {}
+
+            community_results = await asyncio.gather(*[_one_community(i) for i in intents], return_exceptions=True)
+            for intent, res in zip(intents, community_results):
+                if isinstance(res, Exception):
+                    community_out[intent] = {}
+                else:
+                    community_out[intent] = res if isinstance(res, dict) else {}
+
+        # Merge: local matches take priority, community supplements
+        out = self._merge_signifier_matches(local_out, community_out, intents)
 
         # Demo-friendly summary logs (kept compact).
         for intent, payload in out.items():
@@ -793,133 +630,96 @@ class InteractionSolverAgent(Agent, IAgent):
             matches = payload.get("matches") if isinstance(payload.get("matches"), list) else []
             finals = payload.get("final_matches") if isinstance(payload.get("final_matches"), list) else []
             total = payload.get("total_signifiers")
+            community_count = sum(1 for m in matches if isinstance(m, dict) and m.get("source") == "community")
 
             if finals:
                 logger.info(
-                    demo("Signifier search: intent=%r matches=%d final=%d top=%s"),
+                    demo("Signifier search: intent=%r matches=%d (community=%d) final=%d top=%s"),
                     intent,
                     len(matches),
+                    community_count,
                     len(finals),
                     finals[0],
                 )
             else:
                 logger.info(
-                    demo("Signifier search: intent=%r matches=%d final=0 stored_total=%s"),
+                    demo("Signifier search: intent=%r matches=%d (community=%d) final=0 stored_total=%s"),
                     intent,
                     len(matches),
+                    community_count,
                     total if total is not None else "?",
                 )
         return out
 
-    def _build_planning_prompt(self, intents: List[str], context: Dict[str, Any], workspace_id: Optional[str] = None) -> List[Dict[str, str]]:
+    @staticmethod
+    def _merge_signifier_matches(
+        local: Dict[str, Any],
+        community: Dict[str, Any],
+        intents: List[str],
+    ) -> Dict[str, Any]:
         """
-        Build a strict prompt: system with rules + user with intent and context payload.
+        Merge local and community signifier matches.
+
+        Local matches take priority. Community matches supplement gaps.
         """
-        system = (
-            "Return ONLY valid JSON. No markdown. No prose.\n"
-            "\n"
-            "SELF-VALIDATION REQUIRED (do this BEFORE you output):\n"
-            "1) Grounding:\n"
-            "   - Choose an affordance from the provided context.affordances list.\n"
-            "   - step.affordance_uri MUST equal affordance.affordance_id from that list.\n"
-            "   - step.artifact_uri MUST match that affordance.artifact_id.\n"
-            "   - step.method/step.target/step.content_type MUST match that affordance's method/target/content_type.\n"
-            "   - Do NOT invent URIs or actions.\n"
-            "2) Payload/schema:\n"
-            "   - If the selected affordance has input_schema, step.payload MUST satisfy it (required fields, types, enums).\n"
-            "3) Intent coverage:\n"
-            "   - Each step.intent MUST exactly match one of the provided intents.\n"
-            "   - All provided intents MUST be covered by at least one step, unless already satisfied (see below).\n"
-            "4) Redundancy / already satisfied:\n"
-            "   - Use the provided state snapshot to avoid redundant steps.\n"
-            "   - If the current state already satisfies ALL intents, return a strict no-op JSON:\n"
-            "     {\"plan_version\":\"1.2\",\"error\":\"already_satisfied\",\"detail\":\"...\",\"steps\":[]}\n"
-            "4b) Signifier-first planning (STRICT):\n"
-            "   - context.signifier_matches is a dict keyed by intent string.\n"
-            "   - Each entry has:\n"
-            "     - matches: list of {signifier_id, affordance_uri, intent_similarity, shacl_conforms, shacl_violations, payload_hint?}\n"
-            "     - final_matches: list of signifier_id (best-first) that passed SHACL.\n"
-            "   - For each intent:\n"
-            "     1) If final_matches is non-empty, pick signifier_id = final_matches[0].\n"
-            "     2) Find the corresponding entry in matches to get affordance_uri and payload_hint.\n"
-            "     3) Use that affordance_uri ONLY if it exists in context.affordances (affordance_id match) and method/target/content_type match.\n"
-            "     4) If payload_hint is present, use it only if it satisfies the selected affordance input_schema; otherwise construct a valid payload.\n"
-            "     5) If the signifier suggestion is unusable for any reason, ignore it and plan normally.\n"
-            "   - Traceability:\n"
-            "     - If you use a signifier for a step, include step.metadata.used_signifier_id and step.metadata.used_signifier_similarity.\n"
-            "     - If you ignore an available final_matches suggestion, include step.metadata.signifier_ignored_reason.\n"
-            "5) Evidence:\n"
-            "   - Every step must include at least one reasons entry with at least one evidence item grounded in the state.\n"
-            "   - evidence[].artifact MUST be a key from context.state.artifacts.\n"
-            "   - evidence[].property MUST be a full property URI key from that artifact's state dict.\n"
-            "   - evidence[].reading MUST equal the reading from the state snapshot.\n"
-            "\n"
-            "If you cannot satisfy ALL intents using ONLY the provided affordances, return:\n"
-            "{\"plan_version\":\"1.2\",\"error\":\"infeasible\",\"detail\":\"...\",\"steps\":[]}\n"
-        )
+        merged: Dict[str, Any] = {}
+        for intent in intents:
+            local_data = local.get(intent, {})
+            community_data = community.get(intent, {})
 
-        schema_reminder = (
-            "JSON-Plan 1.2 schema:\n"
-            "{\n"
-            '  "plan_version": "1.2",\n'
-            '  "steps": [\n'
-            "    {\n"
-            '      "step_id": <int>,\n'
-            '      "intent": "<intent>",\n'
-            '      "artifact_uri": "<uri>",\n'
-            '      "affordance_uri": "<uri>",\n'
-            '      "action_name": "<name>",\n'
-            '      "method": "<HTTP verb>",\n'
-            '      "target": "<hctl:hasTarget URI>",\n'
-            '      "content_type": "application/json",\n'
-            '      "payload": { },\n'
-            '      "metadata": { },\n'
-            '      "reasons": [\n'
-            "        {\n"
-            '          "property": "<property satisfied>",\n'
-            '          "direction": "<increase|decrease|set>",\n'
-            '          "evidence": [\n'
-            "            {\n"
-            '              "artifact": "<sensor-or-artifact URI>",\n'
-            '              "property": "<property URI>",\n'
-            '              "operator": "<lessThan|lessEqual|greaterThan|greaterEqual|equals>",\n'
-            '              "threshold": "<number|string>",\n'
-            '              "reading": "<number|string>"\n'
-            "            }\n"
-            "          ],\n"
-            '          "why": "One or two sentences."\n'
-            "        }\n"
-            "      ]\n"
-            "    }\n"
-            "  ]\n"
-            "}\n"
-        )
+            if not isinstance(local_data, dict):
+                local_data = {}
+            if not isinstance(community_data, dict):
+                community_data = {}
 
-        user_payload = {
-            "intents": intents,
-            **({"workspace_id": workspace_id} if workspace_id else {}),
-            "affordances": context.get("affordances", []),
-            "state": context.get("state", {}),
-            "signifier_matches": context.get("signifier_matches", {}),
-            "instructions": [
-                "Use only provided affordance URIs and methods; do not invent or alter them.",
-                "If workspace_id is provided, only use affordances/artifacts from that workspace.",
-                "Use signifiers strictly: if signifier_matches[intent].final_matches is non-empty, prefer final_matches[0] for that intent when it is usable.",
-                "If you use a signifier, include step.metadata.used_signifier_id and step.metadata.used_signifier_similarity.",
-                "Cover ALL intents. Each step.intent must match exactly one provided intent.",
-                "Include at least one reason with evidence per step.",
-                "Evidence items must use full artifact URIs and full property URIs from the provided state snapshot.",
-                "If missing info, use placeholders but keep JSON valid.",
-                "Respond with JSON only, no markdown, no prose.",
-            ],
-        }
+            local_matches = local_data.get("matches", []) if isinstance(local_data.get("matches"), list) else []
+            local_finals = local_data.get("final_matches", []) if isinstance(local_data.get("final_matches"), list) else []
+            community_matches = community_data.get("matches", []) if isinstance(community_data.get("matches"), list) else []
+            community_finals = community_data.get("final_matches", []) if isinstance(community_data.get("final_matches"), list) else []
 
-        return [
-            {"role": "system", "content": INTERACTION_SOLVER_SYSTEM_PROMPT.strip()},
-            {"role": "system", "content": system},
-            {"role": "system", "content": schema_reminder},
-            {"role": "user", "content": json.dumps(user_payload, indent=2)},
-        ]
+            # Combine: local first, then community (dedup by signifier_id)
+            seen_ids: set = set()
+            combined_matches: List[Dict[str, Any]] = []
+            for m in local_matches:
+                if isinstance(m, dict):
+                    sid = m.get("signifier_id", "")
+                    if sid not in seen_ids:
+                        seen_ids.add(sid)
+                        combined_matches.append(m)
+            for m in community_matches:
+                if isinstance(m, dict):
+                    sid = m.get("signifier_id", "")
+                    if sid not in seen_ids:
+                        seen_ids.add(sid)
+                        combined_matches.append(m)
+
+            # Finals: local finals first, then community finals
+            combined_finals: List[str] = []
+            seen_final_ids: set = set()
+            for f in local_finals:
+                sf = str(f)
+                if sf not in seen_final_ids:
+                    seen_final_ids.add(sf)
+                    combined_finals.append(sf)
+            for f in community_finals:
+                sf = str(f)
+                if sf not in seen_final_ids:
+                    seen_final_ids.add(sf)
+                    combined_finals.append(sf)
+
+            merged[intent] = {
+                "matches": combined_matches,
+                "final_matches": combined_finals,
+            }
+
+            # Preserve error from local if present
+            if local_data.get("error"):
+                merged[intent]["error"] = local_data["error"]
+
+        return merged
+
+    # NOTE: _build_planning_prompt() removed — BT planning prompt construction is now
+    # handled by AsyncBTPlanner and ami_agents.bt_planning.planning.prompts.
 
 
 class EnvironmentReadyBehaviour(CyclicBehaviour):
@@ -1000,7 +800,7 @@ class GoalRequestBehaviour(CyclicBehaviour):
         if not intents:
             reply = msg.make_reply()
             reply.set_metadata("type", MessageType.GOAL_RESPONSE.value)
-            reply.body = json.dumps({"error": "missing_intent"})
+            reply.body = json.dumps({"plan_type": "behavior_tree", "error": "missing_intent", "tree": None, "intents": []})
             # Propagate correlation_id/thread for request/response pairing.
             corr = msg.get_metadata(META_CORRELATION_ID)
             if corr:
@@ -1025,10 +825,11 @@ class GoalRequestBehaviour(CyclicBehaviour):
             reply.set_metadata("type", MessageType.PLAN_CREATED.value)
             reply.body = json.dumps(
                 {
-                    "plan_version": "1.2",
+                    "plan_type": "behavior_tree",
                     "error": "env_not_ready",
                     "detail": "Environment discovery not completed (timeout).",
-                    "steps": [],
+                    "tree": None,
+                    "intents": intents,
                 },
                 indent=2,
             )
@@ -1044,15 +845,15 @@ class GoalRequestBehaviour(CyclicBehaviour):
 
         try:
             parsed_plan = json.loads(plan_json or "{}")
-            steps = parsed_plan.get("steps") if isinstance(parsed_plan, dict) else None
-            step_count = len(steps) if isinstance(steps, list) else 0
-            used_signifiers = 0
-            if isinstance(steps, list):
-                for s in steps:
-                    meta = s.get("metadata") if isinstance(s, dict) else None
-                    if isinstance(meta, dict) and meta.get("used_signifier_id"):
-                        used_signifiers += 1
-            logger.info(demo("Plan created: steps=%d used_signifiers=%d"), step_count, used_signifiers)
+            tree = parsed_plan.get("tree") if isinstance(parsed_plan, dict) else None
+            has_tree = tree is not None and isinstance(tree, dict) and bool(tree)
+            signifier_reuse = parsed_plan.get("signifier_reuse", False) if isinstance(parsed_plan, dict) else False
+            is_impossible = parsed_plan.get("impossible", False) if isinstance(parsed_plan, dict) else False
+            error = parsed_plan.get("error") if isinstance(parsed_plan, dict) else None
+            logger.info(
+                demo("Plan created: has_tree=%s signifier_reuse=%s impossible=%s error=%s"),
+                has_tree, signifier_reuse, is_impossible, error,
+            )
         except Exception:
             logger.info(demo("Plan created (failed to parse JSON for summary)."))
 

--- a/ami_agents/agents/user_assistant/prompts.py
+++ b/ami_agents/agents/user_assistant/prompts.py
@@ -5,7 +5,7 @@ I. PURPOSE
   Your goal is to:
   1) Understand the user's request.
   2) Derive ONE OR MORE environment-level intents (multi-intent supported).
-  3) Request a single JSON-Plan 1.2 from the Interaction-Solver that satisfies ALL intents.
+  3) Request a behavior tree plan from the Interaction-Solver that satisfies ALL intents.
   4) Present a concise natural-language summary of the plan and ask the user for confirmation.
   5) ONLY if the user confirms, execute the plan.
   6) If the user rejects the plan, discard it and ask what changes they want.
@@ -24,10 +24,10 @@ II. TOOLS (YOU MUST USE THESE CORRECTLY)
   3) request_interaction_plan(intent_list)
      - Send the full list of derived intents to the Interaction-Solver.
      - If the user specifies a workspace (e.g., "in lab308"), scope planning to that workspace by passing workspace_id.
-     - Returns a JSON-Plan 1.2 string (either success plan or strict failure).
+     - Returns a behavior tree plan JSON (plan_type="behavior_tree" with a "tree" field, or an error).
 
   4) store_latest_plan(plan_json)
-     - CRITICAL RULE: If you receive a valid plan (plan_version=1.2 and steps is a non-empty list),
+     - CRITICAL RULE: If you receive a valid plan (plan_type="behavior_tree" with a non-null "tree" field),
        you MUST call store_latest_plan with the EXACT plan string BEFORE summarizing to the user.
 
   5) retrieve_and_clear_latest_plan(discard=false|true)
@@ -35,16 +35,17 @@ II. TOOLS (YOU MUST USE THESE CORRECTLY)
        - If user confirms: discard=false (retrieve for execution, clears stored plan, marks approved).
        - If user rejects: discard=true (discard stored plan).
 
-  6) execute_plan(plan_json, dry_run=false, max_steps?)
+  6) execute_plan(plan_json, dry_run=false)
      - Execute ONLY after user confirmation AND ONLY using the plan_json returned by retrieve_and_clear_latest_plan(discard=false).
+     - The plan is compiled into a behavior tree and executed via a tick loop.
 
 III. STRICT PLANNING POLICY (MULTI-INTENT)
   - You MUST send ALL derived intents together in ONE request_interaction_plan call.
   - Interaction-Solver is expected to either:
-    A) Return a plan covering all intents (steps non-empty), or
-    B) Return an error JSON with steps: [] (strict failure).
+    A) Return a plan with plan_type="behavior_tree" and a non-null "tree" field, or
+    B) Return an error JSON (with "error" field and null "tree").
   - IMPORTANT: You MUST attempt request_interaction_plan at least once before asking any clarifying question.
-  - If you receive strict failure (steps is empty), you must ask ONE clarifying question to help revise the request.
+  - If you receive a failure (tree is null or impossible=true), you must ask ONE clarifying question to help revise the request.
 
 IV. HOW TO SUMMARIZE A PLAN (NO RAW JSON/URIs)
   - Write a short (2-4 sentence) summary of what will happen.

--- a/ami_agents/agents/user_assistant/tools.py
+++ b/ami_agents/agents/user_assistant/tools.py
@@ -13,6 +13,10 @@ from spade_llm import LLMTool
 from ...shared.models.messages import MessageType
 from ...shared.utils.demo_log import demo
 from ...shared.utils.spade_rpc import rpc_call, RpcTimeoutError
+from ...bt_planning.execution.ir_executor import IRExecutor
+from ...bt_planning.execution.base import ExecutionResult
+from ...bt_planning.signifier_bridge import extract_signifiers_from_bt
+from ...shared.community.community_client import CommunitySignifierClient
 
 logger = logging.getLogger("UserAssistant")
 
@@ -102,6 +106,45 @@ def _canonicalize_plan_for_hash(plan: Dict[str, Any]) -> tuple[str, str]:
     return canonical, hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _count_bt_nodes(node: dict) -> int:
+    """Count nodes in a BT JSON IR tree."""
+    if not isinstance(node, dict):
+        return 0
+    count = 1
+    for child in node.get("children", []):
+        count += _count_bt_nodes(child)
+    return count
+
+
+def _bt_preview(node: dict, depth: int = 0) -> str:
+    """Generate a compact preview of a BT JSON IR tree."""
+    if not isinstance(node, dict):
+        return ""
+    name = node.get("name", "?")
+    ntype = node.get("type", "?")
+    parts = [f"{name}({ntype})"]
+    if ntype == "action":
+        url = node.get("action_url", "")
+        action_name = url.rstrip("/").rsplit("/", 1)[-1] if url else "?"
+        params = node.get("parameters", {})
+        parts = [f"{name}:action({action_name})"]
+        if params:
+            parts[0] += f" params={params}"
+    elif ntype == "condition":
+        prop = node.get("property_url", "")
+        prop_name = prop.rstrip("/").rsplit("/", 1)[-1] if prop else "?"
+        expected = node.get("expected_value", "?")
+        parts = [f"{name}:cond({prop_name}=={expected})"]
+    children = node.get("children", [])
+    if children and depth < 2:
+        child_previews = [_bt_preview(c, depth + 1) for c in children[:4]]
+        child_str = ", ".join(child_previews)
+        if len(children) > 4:
+            child_str += ", ..."
+        parts[0] += f" [{child_str}]"
+    return parts[0]
+
+
 class QueryCapabilitiesTool(LLMTool):
     """
     Tool to query the EnvExplorer via XMPP.
@@ -186,6 +229,17 @@ class QueryEnvironmentStateTool(LLMTool):
         if not self.agent:
             return "Error: Agent not initialized in tool."
 
+        # Check state memory cache for single-property lookups
+        state_memory = getattr(self.agent, "state_memory", None)
+        if property_uri and state_memory and state_memory.has(property_uri):
+            cached_value = state_memory.get(property_uri)
+            logger.info(
+                demo("State cache HIT: property_uri=%r value=%r"),
+                property_uri,
+                cached_value,
+            )
+            return json.dumps({"property_uri": property_uri, "value": cached_value, "source": "cache"})
+
         logger.info(
             demo(
                 "UA -> EnvExplorer ENV_STATE_REQUEST: to=%s artifact_id=%r property_uri=%r"
@@ -208,6 +262,22 @@ class QueryEnvironmentStateTool(LLMTool):
                 expect_type=MessageType.ENV_STATE_RESPONSE.value,
                 timeout=15.0,
             )
+
+            # Cache results in state memory
+            if state_memory:
+                try:
+                    body = result.body
+                    state_data = json.loads(body) if isinstance(body, str) else body
+                    if isinstance(state_data, dict):
+                        if property_uri and "value" in state_data:
+                            state_memory.store(property_uri, state_data["value"])
+                        elif "artifacts" in state_data and isinstance(state_data["artifacts"], dict):
+                            state_memory.store_bulk(state_data["artifacts"])
+                        else:
+                            state_memory.store_bulk(state_data)
+                except Exception:
+                    pass  # Best-effort caching
+
             return result.body
         except RpcTimeoutError:
             return "Error: Timeout waiting for reply."
@@ -217,7 +287,7 @@ class QueryEnvironmentStateTool(LLMTool):
 
 class RequestInteractionPlanTool(LLMTool):
     """
-    Request a JSON-Plan 1.2 from the InteractionSolver using a list of intents.
+    Request a behavior tree plan from the InteractionSolver using a list of intents.
 
     Under the hood this sends a GOAL_REQUEST message to the solver and waits for PLAN_CREATED.
     """
@@ -226,7 +296,7 @@ class RequestInteractionPlanTool(LLMTool):
         super().__init__(
             name="request_interaction_plan",
             description=(
-                "Send a list of user intents to the Interaction-Solver and return the JSON-Plan 1.2 response. "
+                "Send a list of user intents to the Interaction-Solver and return a behavior tree plan. "
                 "Use this after deriving intents and scanning environment capabilities."
             ),
             parameters={
@@ -303,13 +373,13 @@ class StoreLatestPlanTool(LLMTool):
         super().__init__(
             name="store_latest_plan",
             description=(
-                "Store the exact JSON-Plan 1.2 string as the latest proposed plan for this conversation. "
+                "Store the exact behavior tree plan JSON string as the latest proposed plan for this conversation. "
                 "Call this immediately after receiving a valid plan, before summarizing."
             ),
             parameters={
                 "type": "object",
                 "properties": {
-                    "plan_json": {"type": "string", "description": "Exact JSON-Plan 1.2 string to store."}
+                    "plan_json": {"type": "string", "description": "Exact behavior tree plan JSON string to store."}
                 },
                 "required": ["plan_json"],
             },
@@ -336,47 +406,27 @@ class StoreLatestPlanTool(LLMTool):
         canonical_plan_str, plan_hash = _canonicalize_plan_for_hash(plan_obj)
         self.agent.store_latest_plan(thread, canonical_plan_str, plan_hash)
 
-        step_count = None
-        step_preview = None
+        node_count = None
+        plan_preview = None
         try:
-            if isinstance(plan_obj.get("steps"), list):
-                steps = plan_obj.get("steps") or []
-                step_count = len(steps)
-
-                def _short_artifact(uri: str) -> str:
-                    s = str(uri or "")
-                    if not s:
-                        return "?"
-                    if "/artifacts/" in s:
-                        s = s.split("/artifacts/", 1)[1]
-                    if "#" in s:
-                        s = s.split("#", 1)[0]
-                    if "/" in s:
-                        s = s.rsplit("/", 1)[-1]
-                    return s or "?"
-
-                previews: List[str] = []
-                for step in steps:
-                    if not isinstance(step, dict):
-                        continue
-                    sid = step.get("step_id")
-                    action = step.get("action_name") or "?"
-                    artifact = _short_artifact(step.get("artifact_uri") or step.get("artifact_id") or "")
-                    payload = step.get("payload") if isinstance(step.get("payload"), dict) else {}
-                    previews.append(f"{sid}:{artifact}.{action} payload={payload}")
-                if previews:
-                    step_preview = "; ".join(previews[:4]) + ("; ..." if len(previews) > 4 else "")
+            tree = plan_obj.get("tree")
+            if isinstance(tree, dict) and tree:
+                node_count = _count_bt_nodes(tree)
+                plan_preview = _bt_preview(tree)
+            elif isinstance(plan_obj.get("steps"), list):
+                # Backward compat: JSON-Plan 1.2 format
+                node_count = len(plan_obj["steps"])
         except Exception:
-            step_count = None
+            node_count = None
 
         logger.info(
-            demo("Plan stored for approval: thread=%s plan_hash=%s steps=%s"),
+            demo("Plan stored for approval: thread=%s plan_hash=%s nodes=%s"),
             thread,
             plan_hash,
-            step_count if step_count is not None else "?",
+            node_count if node_count is not None else "?",
         )
-        if step_preview:
-            logger.info(demo("Plan step preview: %s"), step_preview)
+        if plan_preview:
+            logger.info(demo("BT plan preview: %s"), plan_preview)
         return json.dumps({"ok": True, "plan_hash": plan_hash}, indent=2)
 
 
@@ -433,19 +483,19 @@ class RetrieveAndClearLatestPlanTool(LLMTool):
         return json.dumps({"ok": True, "plan_json": record["plan_json"], "plan_hash": record["plan_hash"]}, indent=2)
 
 
-class ExecutePlanTool(LLMTool):
+class ExecuteBTTool(LLMTool):
     """
-    Execute a JSON-Plan 1.2 plan by invoking each step's affordance.
+    Execute a behavior tree plan by compiling JSON IR to py_trees and running the tick loop.
 
-    Uses `UserAssistantAgent.execution_engine` (YggdrasilIntegration) because it already
-    implements affordance execution via HCTL forms.
+    Uses IRExecutor to compile the BT JSON IR to a py_trees tree, then executes via tick loop.
+    After execution, extracts signifiers from leaf action nodes for recording.
     """
 
     def __init__(self):
         super().__init__(
             name="execute_plan",
             description=(
-                "Executes a JSON-Plan 1.2 by calling each step's affordance in the live environment. "
+                "Executes a behavior tree plan by compiling it and running the tick loop in the live environment. "
                 "Use ONLY when the user explicitly asks to execute/apply the plan."
             ),
             parameters={
@@ -453,17 +503,12 @@ class ExecutePlanTool(LLMTool):
                 "properties": {
                     "plan_json": {
                         "type": "string",
-                        "description": "The JSON-Plan 1.2 object serialized as a JSON string.",
+                        "description": "The behavior tree plan JSON string (containing 'tree' field with JSON IR).",
                     },
                     "dry_run": {
                         "type": "boolean",
-                        "description": "If true, validate and show what would run without executing.",
+                        "description": "If true, validate the tree structure without executing.",
                         "default": False,
-                    },
-                    "max_steps": {
-                        "type": "integer",
-                        "description": "Optional cap on number of steps to execute (from the start).",
-                        "minimum": 1,
                     },
                 },
                 "required": ["plan_json"],
@@ -471,11 +516,12 @@ class ExecutePlanTool(LLMTool):
             func=self.run_impl,
         )
         self.agent = None
+        self._executor = IRExecutor(max_ticks=50)
 
     def set_agent(self, agent):
         self.agent = agent
 
-    async def run_impl(self, plan_json: str, dry_run: bool = False, max_steps: int | None = None):
+    async def run_impl(self, plan_json: str, dry_run: bool = False):
         if not self.agent:
             return "Error: Agent not initialized in tool."
 
@@ -491,8 +537,6 @@ class ExecutePlanTool(LLMTool):
 
         plan_obj = _coerce_plan_dict(plan_json)
         if plan_obj is None and not dry_run and approved_plan_json:
-            # The caller passed an unparseable plan (common LLM serialization issue).
-            # Execute the approved plan instead (safer than executing an unapproved variant).
             logger.info(demo("Executing approved plan (input plan_json not parseable): thread=%s"), thread)
             plan_obj = _coerce_plan_dict(approved_plan_json)
 
@@ -510,163 +554,144 @@ class ExecutePlanTool(LLMTool):
                 return json.dumps({"error": "not_approved", "detail": "Approved plan hash mismatch (internal)."}, indent=2)
             plan_obj = approved_obj
 
-        plan = plan_obj
+        # Extract BT tree spec
+        tree_spec = plan_obj.get("tree")
+        intents = plan_obj.get("intents", [])
+        is_signifier_reuse = plan_obj.get("signifier_reuse", False)
 
-        if str(plan.get("plan_version")) != "1.2":
-            return json.dumps(
-                {"error": "invalid_plan_version", "detail": f"Expected plan_version=1.2, got {plan.get('plan_version')!r}"},
-                indent=2,
-            )
+        if not tree_spec or not isinstance(tree_spec, dict):
+            # Check for error in plan
+            error = plan_obj.get("error")
+            if error:
+                return json.dumps({
+                    "error": error,
+                    "detail": plan_obj.get("detail") or plan_obj.get("explanation", "Plan has no executable tree."),
+                }, indent=2)
+            return json.dumps({"error": "missing_tree", "detail": "Plan has no behavior tree to execute."}, indent=2)
 
-        steps = plan.get("steps")
-        if not isinstance(steps, list) or not steps:
-            return json.dumps({"error": "missing_steps", "detail": "Plan has no steps to execute."}, indent=2)
+        # Dry-run: validate tree structure
+        if dry_run:
+            validation_errors = self._executor.validate_tree(tree_spec)
+            node_count = _count_bt_nodes(tree_spec)
+            preview = _bt_preview(tree_spec)
+            return json.dumps({
+                "dry_run": True,
+                "valid": len(validation_errors) == 0,
+                "node_count": node_count,
+                "preview": preview,
+                "validation_errors": validation_errors,
+            }, indent=2)
 
-        if max_steps is not None:
-            try:
-                max_steps = int(max_steps)
-            except Exception:
-                max_steps = None
-        if max_steps:
-            steps = steps[:max_steps]
-
-        logger.info(demo("Executing plan: thread=%s steps=%d dry_run=%s"), thread, len(steps), bool(dry_run))
-
-        # Ensure engine ready (loads affordance_map required by execute_affordance)
-        try:
-            await self.agent.ensure_execution_engine_ready()
-        except Exception as e:
-            return json.dumps({"error": "engine_init_failed", "detail": str(e)}, indent=2)
-
-        results: List[Dict[str, Any]] = []
-        for idx, step in enumerate(steps, start=1):
-            if not isinstance(step, dict):
-                results.append({"index": idx, "ok": False, "error": "invalid_step", "detail": "Step is not an object."})
-                continue
-
-            step_id = step.get("step_id", idx)
-            affordance_id = step.get("affordance_uri") or step.get("target") or step.get("affordance_id")
-            payload = step.get("payload") if isinstance(step.get("payload"), dict) else {}
-
-            if not affordance_id:
-                results.append({"step_id": step_id, "ok": False, "error": "missing_affordance"})
-                continue
-
-            if dry_run:
-                results.append(
-                    {"step_id": step_id, "ok": True, "dry_run": True, "affordance_id": str(affordance_id), "payload": payload}
-                )
-                continue
-
-            try:
-                logger.info(demo("Step %s: invoking affordance=%s payload=%s"), step_id, str(affordance_id), payload)
-                response_text = await self.agent.execution_engine.execute_affordance(str(affordance_id), payload)
-                ok = response_text is not None
-                results.append(
-                    {
-                        "step_id": step_id,
-                        "ok": ok,
-                        "affordance_id": str(affordance_id),
-                        "payload": payload,
-                        "response": response_text,
-                    }
-                )
-                logger.info(demo("Step %s: ok=%s"), step_id, ok)
-            except Exception as e:
-                results.append(
-                    {
-                        "step_id": step_id,
-                        "ok": False,
-                        "affordance_id": str(affordance_id),
-                        "payload": payload,
-                        "error": "execution_failed",
-                        "detail": str(e),
-                    }
-                )
-                logger.info(demo("Step %s: ok=false error=%s"), step_id, str(e))
-
-            await asyncio.sleep(0)
-
-        if not dry_run:
-            self.agent.clear_approved_plan_hash(thread)
-
-            # Best-effort: record successful executions as signifiers in EnvExplorer (embedded RD4 engine).
-            explorer_jid = (getattr(self.agent, "target_jids", {}) or {}).get("explorer")
-            if explorer_jid:
-                try:
-                    # Do not re-record signifiers for steps that were explicitly recovered from prior signifiers.
-                    # (A reused plan should not create duplicate signifiers.)
-                    recordable_steps: List[Dict[str, Any]] = []
-                    recordable_step_ids: set[str] = set()
-                    for step in steps:
-                        if not isinstance(step, dict):
-                            continue
-                        meta = step.get("metadata") if isinstance(step.get("metadata"), dict) else {}
-                        if meta.get("used_signifier_id"):
-                            continue
-                        recordable_steps.append(step)
-                        sid = step.get("step_id")
-                        if sid is not None:
-                            recordable_step_ids.add(str(sid))
-
-                    if not recordable_steps:
-                        logger.info(demo("Skipping signifier recording: plan steps were recovered from existing signifiers."))
-                    else:
-                        ok_count = sum(
-                            1
-                            for r in results
-                            if isinstance(r, dict)
-                            and r.get("ok")
-                            and (not recordable_step_ids or str(r.get("step_id")) in recordable_step_ids)
-                        )
-                        logger.info(
-                            demo("Recording signifiers in EnvExplorer: ok_steps=%d total_steps=%d"),
-                            ok_count,
-                            len(recordable_steps),
-                        )
-                        plan_to_record: Any = plan
-                        try:
-                            if isinstance(plan, dict):
-                                plan_to_record = {**plan, "steps": recordable_steps}
-                        except Exception:
-                            plan_to_record = plan
-                        rec_res = await rpc_call(
-                            self.agent,
-                            to_jid=str(explorer_jid),
-                            request_type=MessageType.SIGNIFIER_RECORD_EXECUTION_REQUEST.value,
-                            body={
-                                "plan": plan_to_record,
-                                "execution_report": {"results": results},
-                            },
-                            expect_type=MessageType.SIGNIFIER_RECORD_EXECUTION_RESPONSE.value,
-                            timeout=15.0,
-                            thread=(thread if thread and thread != "__default__" else None),
-                        )
-                        created_count = None
-                        try:
-                            rec_payload = json.loads(rec_res.body or "{}")
-                            if isinstance(rec_payload, dict):
-                                created_count = rec_payload.get("created_count")
-                        except Exception:
-                            created_count = None
-
-                        logger.info(
-                            demo("Signifier recording completed: created_count=%s"),
-                            created_count if created_count is not None else "?",
-                        )
-                except Exception as e:
-                    logger.info(demo("Failed to record signifiers in EnvExplorer: %s"), e)
-
-        ok_count = sum(1 for r in results if isinstance(r, dict) and r.get("ok"))
-        logger.info(demo("Execution finished: ok_steps=%d total_steps=%d dry_run=%s"), ok_count, len(results), bool(dry_run))
-
-        return json.dumps(
-            {
-                "plan_version": "1.2",
-                "executed": not dry_run,
-                "dry_run": bool(dry_run),
-                "steps_executed": len(results),
-                "results": results,
-            },
-            indent=2,
+        logger.info(
+            demo("Executing BT plan: thread=%s nodes=%d signifier_reuse=%s"),
+            thread, _count_bt_nodes(tree_spec), is_signifier_reuse,
         )
+
+        # Execute BT in a thread executor (py_trees tick loop is synchronous)
+        loop = asyncio.get_event_loop()
+        try:
+            exec_result: ExecutionResult = await loop.run_in_executor(
+                None,
+                self._executor.execute_from_spec,
+                tree_spec,
+            )
+        except Exception as e:
+            logger.warning(demo("BT execution failed: %s"), e)
+            return json.dumps({
+                "error": "execution_failed",
+                "detail": str(e),
+            }, indent=2)
+
+        logger.info(
+            demo("BT execution complete: success=%s ticks=%d status=%s"),
+            exec_result.success, exec_result.ticks, exec_result.final_status,
+        )
+
+        # Clear approved plan hash after execution
+        self.agent.clear_approved_plan_hash(thread)
+
+        # Invalidate state cache (plan execution changes environment state)
+        state_memory = getattr(self.agent, "state_memory", None)
+        if state_memory:
+            state_memory.clear()
+            logger.info(demo("State memory cache cleared after BT execution"))
+
+        # Extract signifiers from executed BT and record in EnvExplorer
+        if exec_result.success and not is_signifier_reuse:
+            await self._record_signifiers(tree_spec, intents, exec_result, thread)
+
+        return json.dumps({
+            "plan_type": "behavior_tree",
+            "executed": True,
+            "success": exec_result.success,
+            "ticks": exec_result.ticks,
+            "final_status": exec_result.final_status,
+            "tick_history": exec_result.tick_history,
+            "error": exec_result.error,
+        }, indent=2)
+
+    async def _record_signifiers(
+        self, tree_spec: dict, intents: list, exec_result: ExecutionResult, thread: str
+    ) -> None:
+        """Extract signifiers from executed BT and record locally + publish to community."""
+        signifiers = extract_signifiers_from_bt(
+            tree_spec=tree_spec,
+            intents=intents,
+            was_successful=exec_result.success,
+        )
+
+        if not signifiers:
+            logger.info(demo("No signifiers extracted from BT"))
+            return
+
+        logger.info(demo("Recording %d signifiers from BT execution"), len(signifiers))
+
+        # 1. Record signifiers locally via EnvExplorer (embedded RD4 engine)
+        explorer_jid = (getattr(self.agent, "target_jids", {}) or {}).get("explorer")
+        if explorer_jid:
+            try:
+                rec_res = await rpc_call(
+                    self.agent,
+                    to_jid=str(explorer_jid),
+                    request_type=MessageType.SIGNIFIER_RECORD_EXECUTION_REQUEST.value,
+                    body={
+                        "plan_type": "behavior_tree",
+                        "tree": tree_spec,
+                        "signifiers": signifiers,
+                        "execution_result": exec_result.to_dict(),
+                    },
+                    expect_type=MessageType.SIGNIFIER_RECORD_EXECUTION_RESPONSE.value,
+                    timeout=15.0,
+                    thread=(thread if thread and thread != "__default__" else None),
+                )
+                created_count = None
+                try:
+                    rec_payload = json.loads(rec_res.body or "{}")
+                    if isinstance(rec_payload, dict):
+                        created_count = rec_payload.get("created_count")
+                except Exception:
+                    created_count = None
+
+                logger.info(
+                    demo("Local signifier recording: created_count=%s"),
+                    created_count if created_count is not None else "?",
+                )
+            except Exception as e:
+                logger.info(demo("Failed to record signifiers locally: %s"), e)
+
+        # 2. Publish signifiers to community (cross-environment sharing)
+        community_client = getattr(self.agent, "community_client", None)
+        if isinstance(community_client, CommunitySignifierClient):
+            published = 0
+            for sig in signifiers:
+                try:
+                    ok = await community_client.publish_signifier(sig)
+                    if ok:
+                        published += 1
+                except Exception:
+                    pass
+            logger.info(demo("Community signifier publishing: %d/%d published"), published, len(signifiers))
+
+
+# Keep backward-compatible alias
+ExecutePlanTool = ExecuteBTTool

--- a/ami_agents/agents/user_assistant/user_assistant_agent.py
+++ b/ami_agents/agents/user_assistant/user_assistant_agent.py
@@ -31,6 +31,7 @@ from ...shared.utils.spade_rpc import send_via_router
 from ...shared.utils.config_resolver import resolve_yggdrasil_url
 from ...shared.utils.demo_log import demo
 from ...shared.models.plan import Plan, PlanType, PlanStatus
+from ...shared.state_memory import StateMemoryCache
 
 from ...shared.models.messages import MessageType
 from .behaviours import ResponseListenerBehaviour
@@ -42,7 +43,8 @@ from .tools import (
     RequestInteractionPlanTool,
     StoreLatestPlanTool,
     RetrieveAndClearLatestPlanTool,
-    ExecutePlanTool,
+    ExecuteBTTool,
+    ExecutePlanTool,  # backward-compat alias for ExecuteBTTool
 )
 
 from ...environment.integration.integration_engine import YggdrasilIntegration
@@ -162,6 +164,18 @@ class UserAssistantAgent(LLMAgent, IAgent):
         self._plans_by_thread: Dict[str, Dict[str, str]] = {}
         self._approved_plan_hash_by_thread: Dict[str, str] = {}
         self._approved_plan_json_by_thread: Dict[str, str] = {}
+
+        # --- State memory cache (property_uri -> last_known_value) ---
+        self.state_memory = StateMemoryCache()
+
+        # --- Community signifier client (cross-environment sharing via ExecuteBTTool) ---
+        community_cfg = (config.get("planning", {}) or {}).get("community", {}) or {}
+        community_url = community_cfg.get("api_url") or os.getenv("COMMUNITY_API_URL")
+        self.community_client = None
+        if community_url:
+            from ...shared.community.community_client import CommunitySignifierClient
+            self.community_client = CommunitySignifierClient(api_url=community_url)
+            logger.info("Community signifier client enabled (url=%s)", community_url)
 
         # 2. Setup Tools
         explorer_jid = target_jids.get("explorer")

--- a/ami_agents/bt_planning/__init__.py
+++ b/ami_agents/bt_planning/__init__.py
@@ -1,0 +1,12 @@
+"""
+BehaviorTree Planning Module
+
+Ported from behaviortree-planning-for-ami-agents for integration into
+the AAMAS 2026 demo multi-agent system.
+
+Provides:
+- nodes/: py_trees node implementations for HMAS affordances
+- planning/: BT JSON IR generation via LLM
+- execution/: JSON IR compilation to py_trees and tick-loop execution
+- signifier_bridge: BT <-> Signifier conversion utilities
+"""

--- a/ami_agents/bt_planning/execution/__init__.py
+++ b/ami_agents/bt_planning/execution/__init__.py
@@ -1,0 +1,11 @@
+"""
+BT execution module - JSON IR compilation and tick-loop execution.
+"""
+
+from .base import ExecutionResult
+from .ir_executor import IRExecutor
+
+__all__ = [
+    "ExecutionResult",
+    "IRExecutor",
+]

--- a/ami_agents/bt_planning/execution/base.py
+++ b/ami_agents/bt_planning/execution/base.py
@@ -1,0 +1,28 @@
+"""
+Base classes for BT execution.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ExecutionResult:
+    """Result of executing a behavior tree."""
+    success: bool
+    tree_name: str = ""
+    ticks: int = 0
+    final_status: str = ""
+    tick_history: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for tracing."""
+        return {
+            "success": self.success,
+            "tree_name": self.tree_name,
+            "ticks": self.ticks,
+            "final_status": self.final_status,
+            "tick_history": self.tick_history,
+            "error": self.error,
+        }

--- a/ami_agents/bt_planning/execution/ir_executor.py
+++ b/ami_agents/bt_planning/execution/ir_executor.py
@@ -1,0 +1,241 @@
+"""
+IR Executor - compiles JSON IR to py_trees and executes.
+
+Ported from behaviortree-planning-for-ami-agents with adjusted imports
+for the AAMAS 2026 demo multi-agent system.
+"""
+
+import logging
+from typing import Optional
+
+import py_trees
+from py_trees.common import Status
+
+from ..nodes.affordance_nodes import (
+    ActionAffordanceNode,
+    PropertyConditionNode,
+    ComparisonPropertyConditionNode,
+    ComparisonOperator,
+)
+from .base import ExecutionResult
+
+logger = logging.getLogger(__name__)
+
+
+OPERATOR_MAP = {
+    "==": ComparisonOperator.EQUAL,
+    "!=": ComparisonOperator.NOT_EQUAL,
+    ">": ComparisonOperator.GREATER_THAN,
+    ">=": ComparisonOperator.GREATER_THAN_OR_EQUAL,
+    "<": ComparisonOperator.LESS_THAN,
+    "<=": ComparisonOperator.LESS_THAN_OR_EQUAL,
+    "in": ComparisonOperator.IN,
+    "not_in": ComparisonOperator.NOT_IN,
+    "contains": ComparisonOperator.CONTAINS,
+}
+
+
+class IRExecutor:
+    """
+    Executor for JSON IR behavior trees.
+
+    Compiles JSON specification to py_trees objects and executes.
+    """
+
+    def __init__(self, max_ticks: int = 10):
+        self.max_ticks = max_ticks
+
+    def execute_from_spec(self, tree_spec: dict) -> ExecutionResult:
+        """
+        Execute a raw JSON IR tree specification.
+
+        This is the primary entry point for the AAMAS integration,
+        accepting a raw dict instead of a Plan object.
+
+        Args:
+            tree_spec: JSON IR tree specification dict
+
+        Returns:
+            ExecutionResult with execution details
+        """
+        if not tree_spec:
+            logger.info("No behavior tree to execute")
+            return ExecutionResult(
+                success=True,
+                final_status="No behavior tree to execute.",
+                ticks=0,
+                tick_history=[],
+            )
+
+        try:
+            logger.info("Compiling JSON IR to py_trees")
+            tree = self._compile(tree_spec)
+            logger.info(f"Compiled tree: {tree.name}")
+
+            logger.info("Executing behavior tree")
+            result = self._execute_tree(tree)
+            return result
+
+        except Exception as e:
+            logger.error(f"Execution failed: {e}")
+            return ExecutionResult(
+                success=False,
+                error=str(e),
+            )
+
+    def _compile(self, spec: dict) -> py_trees.behaviour.Behaviour:
+        """
+        Compile a JSON specification to py_trees.
+
+        Args:
+            spec: JSON tree specification
+
+        Returns:
+            py_trees behavior
+        """
+        node_type = spec.get("type")
+        name = spec.get("name", "unnamed")
+
+        if node_type == "sequence":
+            children = [self._compile(child) for child in spec.get("children", [])]
+            return py_trees.composites.Sequence(name=name, memory=True, children=children)
+
+        elif node_type == "selector":
+            children = [self._compile(child) for child in spec.get("children", [])]
+            return py_trees.composites.Selector(name=name, memory=False, children=children)
+
+        elif node_type == "parallel":
+            children = [self._compile(child) for child in spec.get("children", [])]
+            policy_name = spec.get("policy", "success_on_all")
+            if policy_name == "success_on_one":
+                policy = py_trees.common.ParallelPolicy.SuccessOnOne()
+            else:
+                policy = py_trees.common.ParallelPolicy.SuccessOnAll()
+            return py_trees.composites.Parallel(name=name, policy=policy, children=children)
+
+        elif node_type == "action":
+            return ActionAffordanceNode(
+                name=name,
+                action_url=spec["action_url"],
+                parameters=spec.get("parameters", {}),
+            )
+
+        elif node_type == "condition":
+            operator = spec.get("operator")
+            if operator and operator != "==":
+                return ComparisonPropertyConditionNode(
+                    name=name,
+                    property_url=spec["property_url"],
+                    expected_value=spec["expected_value"],
+                    operator=OPERATOR_MAP.get(operator, ComparisonOperator.EQUAL),
+                    value_path=spec.get("value_path"),
+                )
+            else:
+                return PropertyConditionNode(
+                    name=name,
+                    property_url=spec["property_url"],
+                    expected_value=spec["expected_value"],
+                    value_path=spec.get("value_path"),
+                )
+
+        else:
+            raise ValueError(f"Unknown node type: {node_type}")
+
+    def _execute_tree(self, tree: py_trees.behaviour.Behaviour) -> ExecutionResult:
+        """
+        Execute a compiled behavior tree.
+
+        Args:
+            tree: Compiled py_trees behavior
+
+        Returns:
+            ExecutionResult with execution details
+        """
+        tree.setup_with_descendants()
+
+        result = ExecutionResult(
+            success=False,
+            tree_name=tree.name,
+            ticks=0,
+            tick_history=[],
+        )
+
+        for tick in range(self.max_ticks):
+            result.ticks = tick + 1
+            tree.tick_once()
+
+            status_name = tree.status.name
+            result.tick_history.append(status_name)
+            logger.debug(f"Tick {tick + 1}: {status_name}")
+
+            if tree.status == Status.SUCCESS:
+                result.final_status = "SUCCESS"
+                result.success = True
+                break
+            elif tree.status == Status.FAILURE:
+                result.final_status = "FAILURE"
+                result.success = False
+                break
+        else:
+            result.final_status = "RUNNING (max ticks reached)"
+
+        tree.shutdown()
+        logger.info(f"Execution complete: {result.final_status} after {result.ticks} ticks")
+        return result
+
+    def validate_tree(self, spec: dict) -> list[str]:
+        """
+        Public validation method for tree specs.
+
+        Args:
+            spec: JSON tree specification
+
+        Returns:
+            List of validation error strings (empty if valid)
+        """
+        return self._validate_tree(spec)
+
+    def _validate_tree(self, spec: dict, path: str = "tree") -> list[str]:
+        """Validate that the tree spec is non-empty and structurally sound."""
+        errors: list[str] = []
+
+        if not spec:
+            errors.append(f"{path}: tree is empty")
+            return errors
+
+        if not isinstance(spec, dict):
+            errors.append(f"{path}: expected object, got {type(spec).__name__}")
+            return errors
+
+        # 'name' is optional -- the compiler defaults to "unnamed" and the
+        # AsyncBTPlanner normalizer fills in sensible defaults.  We only warn
+        # (do NOT add to errors) so that trees without names still pass.
+        node_type = spec.get("type")
+        valid_types = {"sequence", "selector", "parallel", "action", "condition"}
+        if node_type not in valid_types:
+            errors.append(f"{path}: missing or invalid 'type'")
+
+        # Composite nodes
+        if node_type in {"sequence", "selector", "parallel"}:
+            children = spec.get("children")
+            if not isinstance(children, list) or not children:
+                errors.append(f"{path}: composite nodes require non-empty 'children'")
+            else:
+                for idx, child in enumerate(children):
+                    errors.extend(
+                        self._validate_tree(child, path=f"{path}.children[{idx}]")
+                    )
+        # Action nodes
+        elif node_type == "action":
+            action_url = spec.get("action_url")
+            if not action_url or not isinstance(action_url, str):
+                errors.append(f"{path}: action nodes require 'action_url'")
+        # Condition nodes
+        elif node_type == "condition":
+            property_url = spec.get("property_url")
+            if not property_url or not isinstance(property_url, str):
+                errors.append(f"{path}: condition nodes require 'property_url'")
+            if "expected_value" not in spec:
+                errors.append(f"{path}: condition nodes require 'expected_value'")
+
+        return errors

--- a/ami_agents/bt_planning/nodes/__init__.py
+++ b/ami_agents/bt_planning/nodes/__init__.py
@@ -1,0 +1,30 @@
+"""
+py_trees behavior tree node implementations for HMAS affordances.
+"""
+
+from .affordance_nodes import (
+    ActionAffordanceNode,
+    PropertyAffordanceNode,
+    PropertyConditionNode,
+    ComparisonPropertyConditionNode,
+    ComparisonOperator,
+    ActionResult,
+    PropertyValue,
+)
+from .http_client import HTTPClient, HTTPClientConfig, HTTPError, HTTPResponse
+from .blackboard_keys import BlackboardKeys
+
+__all__ = [
+    "ActionAffordanceNode",
+    "PropertyAffordanceNode",
+    "PropertyConditionNode",
+    "ComparisonPropertyConditionNode",
+    "ComparisonOperator",
+    "ActionResult",
+    "PropertyValue",
+    "HTTPClient",
+    "HTTPClientConfig",
+    "HTTPError",
+    "HTTPResponse",
+    "BlackboardKeys",
+]

--- a/ami_agents/bt_planning/nodes/affordance_nodes.py
+++ b/ami_agents/bt_planning/nodes/affordance_nodes.py
@@ -1,0 +1,862 @@
+"""
+Behavior Tree Affordance Nodes
+
+This module provides py-trees behavior tree node templates for working with
+HMAS (Hypermedia Multi-Agent Systems) Thing Description affordances.
+
+Node Types:
+- ActionAffordanceNode: Execute action affordances (POST requests)
+- PropertyAffordanceNode: Read property affordances (GET requests)
+- PropertyConditionNode: Check if property matches expected value
+- ComparisonPropertyConditionNode: Compare property values using operators
+
+All nodes follow the py-trees Status convention:
+- SUCCESS: Operation completed successfully
+- FAILURE: Operation failed or condition not met
+- RUNNING: Operation in progress (for async operations)
+"""
+
+import py_trees
+from py_trees.common import Status
+from typing import Any, Dict, List, Optional
+from enum import Enum
+from dataclasses import dataclass
+import logging
+
+from .http_client import HTTPClient, HTTPClientConfig, HTTPError
+from .blackboard_keys import BlackboardKeys
+
+logger = logging.getLogger(__name__)
+
+
+class ComparisonOperator(Enum):
+    """
+    Comparison operators for property condition checks.
+    
+    Used by ComparisonPropertyConditionNode to compare property values
+    against expected values using different comparison semantics.
+    """
+    EQUAL = "=="
+    NOT_EQUAL = "!="
+    GREATER_THAN = ">"
+    GREATER_THAN_OR_EQUAL = ">="
+    LESS_THAN = "<"
+    LESS_THAN_OR_EQUAL = "<="
+    IN = "in"  # Check if value is in a list/set
+    NOT_IN = "not_in"  # Check if value is not in a list/set
+    CONTAINS = "contains"  # Check if value contains substring/element
+    MATCHES = "matches"  # Regex match (for strings)
+
+
+@dataclass
+class ActionResult:
+    """
+    Encapsulates the result of an action affordance invocation.
+    
+    Attributes:
+        success: Whether the action completed successfully
+        status_code: HTTP status code from the response
+        response_body: Parsed response body (JSON or string)
+        error_message: Error description if action failed
+        elapsed_time: Time taken for the action in seconds
+        url: The action URL that was invoked
+    """
+    success: bool
+    status_code: Optional[int] = None
+    response_body: Any = None
+    error_message: Optional[str] = None
+    elapsed_time: float = 0.0
+    url: str = ""
+
+
+@dataclass
+class PropertyValue:
+    """
+    Encapsulates a property affordance value reading.
+    
+    Attributes:
+        success: Whether the property was read successfully
+        value: The property value (can be any JSON-compatible type)
+        status_code: HTTP status code from the response
+        error_message: Error description if read failed
+        elapsed_time: Time taken for the read in seconds
+        url: The property URL that was queried
+    """
+    success: bool
+    value: Any = None
+    status_code: Optional[int] = None
+    error_message: Optional[str] = None
+    elapsed_time: float = 0.0
+    url: str = ""
+
+
+class ActionAffordanceNode(py_trees.behaviour.Behaviour):
+    """
+    Behavior tree node for invoking action affordances.
+    
+    This node makes an HTTP POST request to the action URL with the provided
+    parameters. It can be used for any action affordance defined in a Thing
+    Description, such as turnOn, setColor, pickup, stack, etc.
+    
+    The node follows py-trees conventions:
+    - setup(): Initialize HTTP client and validate configuration
+    - initialise(): Reset state for new tick cycle
+    - update(): Execute the action and return status
+    - terminate(): Clean up resources
+    
+    Example:
+        # Simple action without parameters
+        turn_on = ActionAffordanceNode(
+            name="TurnOnLight",
+            action_url="http://localhost:8080/workspaces/home0/balcony/artifacts/balconyLight/turn_on"
+        )
+        
+        # Action with parameters
+        set_brightness = ActionAffordanceNode(
+            name="SetBrightness",
+            action_url="http://localhost:8080/workspaces/home0/corridor/artifacts/corridorLight/set_brightness",
+            parameters={"brightness": 75}
+        )
+        
+        # Action with dynamic parameters from blackboard
+        dynamic_action = ActionAffordanceNode(
+            name="DynamicSetColor",
+            action_url="http://localhost:8080/artifacts/light/set_color",
+            parameter_keys={"color": "user/selected_color"}
+        )
+        
+        # Blocksworld stack action
+        stack_action = ActionAffordanceNode(
+            name="StackBlocks",
+            action_url="http://localhost:8080/workspaces/blocksworld/artifacts/world-1/stack",
+            parameters={"target_block": "a", "to_block": "b"}
+        )
+    
+    Attributes:
+        action_url: The HTTP endpoint for the action affordance
+        parameters: Static parameters to send with the action
+        parameter_keys: Blackboard keys to read dynamic parameters from
+        store_result: Whether to store the result on the blackboard
+        result_key: Blackboard key for storing the result
+    """
+    
+    def __init__(
+        self,
+        name: str,
+        action_url: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        parameter_keys: Optional[Dict[str, str]] = None,
+        store_result: bool = True,
+        result_key: Optional[str] = None,
+    ):
+        """
+        Initialize the action affordance node.
+        
+        Args:
+            name: The name of this behavior tree node
+            action_url: HTTP endpoint URL for the action affordance
+            parameters: Static parameters to include in the request body
+            parameter_keys: Map of parameter names to blackboard keys for dynamic values
+            store_result: Whether to store the action result on the blackboard
+            result_key: Custom blackboard key for the result (defaults to standard key)
+        """
+        super().__init__(name)
+        
+        self.action_url = action_url
+        self.parameters = parameters or {}
+        self.parameter_keys = parameter_keys or {}
+        self.store_result = store_result
+        self.result_key = result_key or BlackboardKeys.LAST_ACTION_RESULT
+
+        # HTTP client
+        self._http_client: Optional[HTTPClient] = None
+        
+        # Runtime state
+        self._last_result: Optional[ActionResult] = None
+        
+        # Blackboard setup
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(
+            key=self.result_key,
+            access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key=BlackboardKeys.LAST_ACTION_URL,
+            access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key=BlackboardKeys.LAST_ACTION_STATUS_CODE,
+            access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key=BlackboardKeys.LAST_ACTION_ERROR,
+            access=py_trees.common.Access.WRITE
+        )
+        
+        # Register read access for dynamic parameter keys
+        for bb_key in self.parameter_keys.values():
+            self.blackboard.register_key(
+                key=bb_key,
+                access=py_trees.common.Access.READ
+            )
+    
+    def setup(self, **kwargs) -> None:
+        """
+        Setup the node before first tick.
+        
+        Creates the HTTP client if not provided during initialization.
+        """
+        if self._http_client is None:
+            self._http_client = HTTPClient(config=HTTPClientConfig())
+        
+        logger.debug(f"[{self.name}] Setup complete, action URL: {self.action_url}")
+    
+    def initialise(self) -> None:
+        """
+        Reset state at the start of a new tick cycle.
+        """
+        self._last_result = None
+        logger.debug(f"[{self.name}] Initializing for new tick")
+    
+    def _build_parameters(self) -> Dict[str, Any]:
+        """
+        Build the final parameter dictionary by combining static and dynamic params.
+        
+        Returns:
+            Combined parameter dictionary
+        """
+        params = dict(self.parameters)
+        
+        # Resolve dynamic parameters from blackboard
+        for param_name, bb_key in self.parameter_keys.items():
+            try:
+                value = self.blackboard.get(bb_key)
+
+                if isinstance(value, PropertyValue):
+                    value = value.value  # Extract actual value
+
+                params[param_name] = value
+            except KeyError:
+                logger.warning(
+                    f"[{self.name}] Blackboard key '{bb_key}' not found for parameter '{param_name}'"
+                )
+        
+        return params
+    
+    def update(self) -> Status:
+        """
+        Execute the action affordance.
+        
+        Makes an HTTP POST request to the action URL with the configured parameters.
+        
+        Returns:
+            Status.SUCCESS if the action completed successfully
+            Status.FAILURE if the action failed
+        """
+        params = self._build_parameters()
+        
+        logger.info(f"[{self.name}] Invoking action: {self.action_url}")
+        logger.debug(f"[{self.name}] Parameters: {params}")
+        
+        try:
+            response = self._http_client.post(self.action_url, payload=params)
+            
+            self._last_result = ActionResult(
+                success=response.is_success,
+                status_code=response.status_code,
+                response_body=response.body,
+                elapsed_time=response.elapsed_time,
+                url=self.action_url
+            )
+            
+            if response.is_success:
+                logger.info(
+                    f"[{self.name}] Action succeeded (status: {response.status_code}, "
+                    f"time: {response.elapsed_time:.3f}s)"
+                )
+                
+                self._store_result()
+                return Status.SUCCESS
+            else:
+                self._last_result.error_message = f"HTTP {response.status_code}"
+                logger.warning(
+                    f"[{self.name}] Action failed with status {response.status_code}"
+                )
+                
+                self._store_result()
+                return Status.FAILURE
+
+        except HTTPError as e:
+            self._last_result = ActionResult(
+                success=False,
+                status_code=e.status_code,
+                response_body=e.response_body,
+                error_message=e.message,
+                url=self.action_url
+            )
+            
+            logger.error(f"[{self.name}] Action failed: {e.message}")
+            
+            self._store_result()
+            return Status.FAILURE
+    
+    def _store_result(self) -> None:
+        """Store the action result on the blackboard."""
+        if self.store_result and self._last_result:
+            self.blackboard.set(self.result_key, self._last_result)
+            self.blackboard.set(BlackboardKeys.LAST_ACTION_URL, self._last_result.url)
+            self.blackboard.set(
+                BlackboardKeys.LAST_ACTION_STATUS_CODE,
+                self._last_result.status_code
+            )
+            if self._last_result.error_message:
+                self.blackboard.set(
+                    BlackboardKeys.LAST_ACTION_ERROR,
+                    self._last_result.error_message
+                )
+    
+    def terminate(self, new_status: Status) -> None:
+        """
+        Cleanup when the node is terminated.
+        
+        Args:
+            new_status: The status that caused termination
+        """
+        logger.debug(f"[{self.name}] Terminating with status {new_status}")
+    
+    @property
+    def last_result(self) -> Optional[ActionResult]:
+        """Get the result of the last action execution."""
+        return self._last_result
+
+
+class PropertyAffordanceNode(py_trees.behaviour.Behaviour):
+    """
+    Behavior tree node for reading property affordances.
+    
+    This node makes an HTTP GET request to the property URL and stores
+    the result on the blackboard. It can be used to read any property
+    defined in a Thing Description, such as state, temperature, brightness, etc.
+    
+    Example:
+        # Read a simple property
+        read_state = PropertyAffordanceNode(
+            name="ReadLightState",
+            property_url="http://localhost:8080/workspaces/home0/balcony/artifacts/balconyLight/properties/state"
+        )
+        
+        # Read with custom result key
+        read_temp = PropertyAffordanceNode(
+            name="ReadTemperature",
+            property_url="http://localhost:8080/artifacts/thermostat/properties/temperature",
+            result_key="sensors/current_temperature"
+        )
+        
+        # Read blocksworld state
+        read_world = PropertyAffordanceNode(
+            name="ReadWorldState",
+            property_url="http://localhost:8080/workspaces/blocksworld/artifacts/world-1/properties/state"
+        )
+    
+    Attributes:
+        property_url: The HTTP endpoint for the property affordance
+        store_result: Whether to store the result on the blackboard
+        result_key: Blackboard key for storing the value
+        property_name: Name of the property (extracted from URL or specified)
+    """
+    
+    def __init__(
+        self,
+        name: str,
+        property_url: str,
+        store_result: bool = True,
+        result_key: Optional[str] = None,
+        property_name: Optional[str] = None,
+    ):
+        """
+        Initialize the property affordance node.
+        
+        Args:
+            name: The name of this behavior tree node
+            property_url: HTTP endpoint URL for the property affordance
+            store_result: Whether to store the property value on the blackboard
+            result_key: Custom blackboard key for the value (defaults to standard key)
+            property_name: Optional name of the property (auto-extracted if not provided)
+        """
+        super().__init__(name)
+        
+        self.property_url = property_url
+        self.store_result = store_result
+        self.result_key = result_key or BlackboardKeys.LAST_PROPERTY_VALUE
+        self.property_name = property_name or self._extract_property_name(property_url)
+
+        # HTTP client
+        self._http_client: Optional[HTTPClient] = None
+        
+        # Runtime state
+        self._last_value: Optional[PropertyValue] = None
+        
+        # Blackboard setup
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        self.blackboard.register_key(
+            key=self.result_key,
+            access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key=BlackboardKeys.LAST_PROPERTY_URL,
+            access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key=BlackboardKeys.LAST_PROPERTY_STATUS_CODE,
+            access=py_trees.common.Access.WRITE
+        )
+        self.blackboard.register_key(
+            key=BlackboardKeys.LAST_PROPERTY_ERROR,
+            access=py_trees.common.Access.WRITE
+        )
+        
+        # Also register a property-specific key
+        if self.property_name:
+            self.property_key = BlackboardKeys.property_value_key(self.property_name)
+            self.blackboard.register_key(
+                key=self.property_key,
+                access=py_trees.common.Access.WRITE
+            )
+    
+    @staticmethod
+    def _extract_property_name(url: str) -> Optional[str]:
+        """Extract the property name from the URL."""
+        # URLs typically end with /properties/<name>
+        if "/properties/" in url:
+            return url.split("/properties/")[-1].split("?")[0].split("#")[0]
+        return None
+    
+    def setup(self, **kwargs) -> None:
+        """Setup the node before first tick."""
+        if self._http_client is None:
+            self._http_client = HTTPClient(config=HTTPClientConfig())
+        
+        logger.debug(f"[{self.name}] Setup complete, property URL: {self.property_url}")
+    
+    def initialise(self) -> None:
+        """Reset state at the start of a new tick cycle."""
+        self._last_value = None
+        logger.debug(f"[{self.name}] Initializing for new tick")
+    
+    def update(self) -> Status:
+        """
+        Read the property affordance.
+        
+        Makes an HTTP GET request to the property URL and stores the result.
+        
+        Returns:
+            Status.SUCCESS if the property was read successfully
+            Status.FAILURE if the read failed
+        """
+        logger.info(f"[{self.name}] Reading property: {self.property_url}")
+        
+        try:
+            response = self._http_client.get(self.property_url)
+            
+            self._last_value = PropertyValue(
+                success=response.is_success,
+                value=response.body,
+                status_code=response.status_code,
+                elapsed_time=response.elapsed_time,
+                url=self.property_url
+            )
+            
+            if response.is_success:
+                logger.info(
+                    f"[{self.name}] Property read succeeded: {response.body} "
+                    f"(time: {response.elapsed_time:.3f}s)"
+                )
+                
+                self._store_result()
+                return Status.SUCCESS
+            else:
+                self._last_value.error_message = f"HTTP {response.status_code}"
+                logger.warning(
+                    f"[{self.name}] Property read failed with status {response.status_code}"
+                )
+                
+                self._store_result()
+                return Status.FAILURE
+                
+        except HTTPError as e:
+            self._last_value = PropertyValue(
+                success=False,
+                status_code=e.status_code,
+                error_message=e.message,
+                url=self.property_url
+            )
+            
+            logger.error(f"[{self.name}] Property read failed: {e.message}")
+            
+            self._store_result()
+            return Status.FAILURE
+    
+    def _store_result(self) -> None:
+        """Store the property value on the blackboard."""
+        if self.store_result and self._last_value:
+            self.blackboard.set(self.result_key, self._last_value)
+            self.blackboard.set(BlackboardKeys.LAST_PROPERTY_URL, self._last_value.url)
+            self.blackboard.set(
+                BlackboardKeys.LAST_PROPERTY_STATUS_CODE,
+                self._last_value.status_code
+            )
+            
+            # Store the actual value with property-specific key
+            if self.property_name and self._last_value.value is not None:
+                self.blackboard.set(self.property_key, self._last_value.value)
+            
+            if self._last_value.error_message:
+                self.blackboard.set(
+                    BlackboardKeys.LAST_PROPERTY_ERROR,
+                    self._last_value.error_message
+                )
+    
+    def terminate(self, new_status: Status) -> None:
+        """Cleanup when the node is terminated."""
+        logger.debug(f"[{self.name}] Terminating with status {new_status}")
+    
+    @property
+    def last_value(self) -> Optional[PropertyValue]:
+        """Get the last property value reading."""
+        return self._last_value
+
+
+class PropertyConditionNode(py_trees.behaviour.Behaviour):
+    """
+    Behavior tree condition node for checking property values.
+    
+    This node reads a property and compares it against an expected value.
+    It's useful for implementing guards and preconditions in behavior trees.
+    
+    The node always returns immediately (never RUNNING), making it suitable
+    for use in conditional branches.
+    
+    Example:
+        # Check if light is on
+        is_light_on = PropertyConditionNode(
+            name="IsLightOn",
+            property_url="http://localhost:8080/artifacts/light/properties/state",
+            expected_value="on"
+        )
+        
+        # Check with comparison from blackboard value
+        brightness_check = PropertyConditionNode(
+            name="IsBrightEnough",
+            property_url="http://localhost:8080/artifacts/light/properties/brightness",
+            expected_value_key="target/brightness"
+        )
+        
+        # Check nested property (e.g., blocksworld hand)
+        hand_empty = PropertyConditionNode(
+            name="IsHandEmpty",
+            property_url="http://localhost:8080/workspaces/blocksworld/artifacts/world-1/properties/state",
+            expected_value="empty",
+            value_path=["hand"]  # Navigate to state.hand
+        )
+    
+    Attributes:
+        property_url: The HTTP endpoint for the property affordance
+        expected_value: The value to compare against
+        expected_value_key: Blackboard key for dynamic expected value
+        value_path: Path to navigate in nested response objects
+        negate: If True, succeed when values DON'T match
+    """
+    
+    def __init__(
+        self,
+        name: str,
+        property_url: str,
+        expected_value: Any = None,
+        expected_value_key: Optional[str] = None,
+        value_path: Optional[List[str]] = None,
+        negate: bool = False,
+    ):
+        """
+        Initialize the property condition node.
+        
+        Args:
+            name: The name of this behavior tree node
+            property_url: HTTP endpoint URL for the property affordance
+            expected_value: The value to compare against (static)
+            expected_value_key: Blackboard key for dynamic expected value
+            value_path: List of keys to navigate nested response objects
+            negate: If True, return SUCCESS when values don't match
+        """
+        super().__init__(name)
+        
+        self.property_url = property_url
+        self.expected_value = expected_value
+        self.expected_value_key = expected_value_key
+        self.value_path = value_path or []
+        self.negate = negate
+
+        # HTTP client
+        self._http_client: Optional[HTTPClient] = None
+        
+        # Runtime state
+        self._actual_value: Any = None
+        self._comparison_result: Optional[bool] = None
+        
+        # Blackboard setup
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        
+        if expected_value_key:
+            self.blackboard.register_key(
+                key=expected_value_key,
+                access=py_trees.common.Access.READ
+            )
+    
+    def setup(self, **kwargs) -> None:
+        """Setup the node before first tick."""
+        if self._http_client is None:
+            self._http_client = HTTPClient(config=HTTPClientConfig())
+    
+    def initialise(self) -> None:
+        """Reset state at the start of a new tick cycle."""
+        self._actual_value = None
+        self._comparison_result = None
+    
+    def _get_expected_value(self) -> Any:
+        """Get the expected value from static config or blackboard."""
+        if self.expected_value_key:
+            try:
+                return self.blackboard.get(self.expected_value_key)
+            except KeyError:
+                logger.warning(
+                    f"[{self.name}] Expected value key '{self.expected_value_key}' not found"
+                )
+                return self.expected_value
+        return self.expected_value
+    
+    def _navigate_value(self, value: Any) -> Any:
+        """Navigate to a nested value using the value_path."""
+        result = value
+        for key in self.value_path:
+            if isinstance(result, dict):
+                result = result.get(key)
+            elif isinstance(result, list) and key.isdigit():
+                idx = int(key)
+                result = result[idx] if 0 <= idx < len(result) else None
+            else:
+                return None
+        return result
+    
+    def update(self) -> Status:
+        """
+        Read the property and compare against expected value.
+        
+        Returns:
+            Status.SUCCESS if the comparison matches (or doesn't match if negate=True)
+            Status.FAILURE if the comparison fails or property cannot be read
+        """
+        logger.debug(f"[{self.name}] Checking property: {self.property_url}")
+        
+        try:
+            response = self._http_client.get(self.property_url)
+            
+            if not response.is_success:
+                logger.warning(
+                    f"[{self.name}] Failed to read property: HTTP {response.status_code}"
+                )
+                return Status.FAILURE
+            
+            # Navigate to the target value
+            self._actual_value = self._navigate_value(response.body)
+            expected = self._get_expected_value()
+            
+            # Perform comparison
+            self._comparison_result = (self._actual_value == expected)
+            
+            # Apply negation if configured
+            final_result = not self._comparison_result if self.negate else self._comparison_result
+            
+            logger.debug(
+                f"[{self.name}] Comparison: {self._actual_value} == {expected} -> "
+                f"{self._comparison_result} (negate={self.negate}, final={final_result})"
+            )
+            
+            return Status.SUCCESS if final_result else Status.FAILURE
+            
+        except HTTPError as e:
+            logger.error(f"[{self.name}] HTTP error: {e.message}")
+            return Status.FAILURE
+    
+    def terminate(self, new_status: Status) -> None:
+        """Cleanup when the node is terminated."""
+        pass
+    
+    @property
+    def actual_value(self) -> Any:
+        """Get the actual value that was read."""
+        return self._actual_value
+    
+    @property
+    def comparison_result(self) -> Optional[bool]:
+        """Get the raw comparison result (before negation)."""
+        return self._comparison_result
+
+
+class ComparisonPropertyConditionNode(PropertyConditionNode):
+    """
+    Extended property condition node supporting various comparison operators.
+    
+    This node extends PropertyConditionNode with support for different
+    comparison operators beyond simple equality.
+    
+    Example:
+        # Check if temperature is above threshold
+        temp_check = ComparisonPropertyConditionNode(
+            name="IsTooHot",
+            property_url="http://localhost:8080/artifacts/thermostat/properties/temperature",
+            expected_value=25,
+            operator=ComparisonOperator.GREATER_THAN
+        )
+        
+        # Check if mode is one of several values
+        mode_check = ComparisonPropertyConditionNode(
+            name="IsCoolingMode",
+            property_url="http://localhost:8080/artifacts/ac/properties/mode",
+            expected_value=["cool", "auto"],
+            operator=ComparisonOperator.IN
+        )
+        
+        # Check if brightness is in acceptable range
+        brightness_min = ComparisonPropertyConditionNode(
+            name="BrightnessAboveMin",
+            property_url="http://localhost:8080/artifacts/light/properties/brightness",
+            expected_value=20,
+            operator=ComparisonOperator.GREATER_THAN_OR_EQUAL
+        )
+    """
+    
+    def __init__(
+        self,
+        name: str,
+        property_url: str,
+        expected_value: Any = None,
+        operator: ComparisonOperator = ComparisonOperator.EQUAL,
+        expected_value_key: Optional[str] = None,
+        value_path: Optional[List[str]] = None,
+        negate: bool = False,
+    ):
+        """
+        Initialize the comparison property condition node.
+        
+        Args:
+            name: The name of this behavior tree node
+            property_url: HTTP endpoint URL for the property affordance
+            expected_value: The value to compare against
+            operator: The comparison operator to use
+            expected_value_key: Blackboard key for dynamic expected value
+            value_path: List of keys to navigate nested response objects
+            negate: If True, return SUCCESS when comparison is False
+        """
+        super().__init__(
+            name=name,
+            property_url=property_url,
+            expected_value=expected_value,
+            expected_value_key=expected_value_key,
+            value_path=value_path,
+            negate=negate,
+        )
+
+        self.operator = operator
+    
+    def _compare(self, actual: Any, expected: Any) -> bool:
+        """
+        Compare two values using the configured operator.
+        
+        Args:
+            actual: The actual value from the property
+            expected: The expected value to compare against
+            
+        Returns:
+            True if the comparison succeeds, False otherwise
+        """
+        try:
+            if self.operator == ComparisonOperator.EQUAL:
+                return actual == expected
+            elif self.operator == ComparisonOperator.NOT_EQUAL:
+                return actual != expected
+            elif self.operator == ComparisonOperator.GREATER_THAN:
+                return actual > expected
+            elif self.operator == ComparisonOperator.GREATER_THAN_OR_EQUAL:
+                return actual >= expected
+            elif self.operator == ComparisonOperator.LESS_THAN:
+                return actual < expected
+            elif self.operator == ComparisonOperator.LESS_THAN_OR_EQUAL:
+                return actual <= expected
+            elif self.operator == ComparisonOperator.IN:
+                return actual in expected
+            elif self.operator == ComparisonOperator.NOT_IN:
+                return actual not in expected
+            elif self.operator == ComparisonOperator.CONTAINS:
+                if isinstance(actual, str):
+                    return expected in actual
+                elif isinstance(actual, (list, tuple, set)):
+                    return expected in actual
+                elif isinstance(actual, dict):
+                    return expected in actual
+                return False
+            elif self.operator == ComparisonOperator.MATCHES:
+                import re
+                if isinstance(actual, str) and isinstance(expected, str):
+                    return bool(re.match(expected, actual))
+                return False
+            else:
+                logger.warning(f"[{self.name}] Unknown operator: {self.operator}")
+                return False
+        except TypeError as e:
+            logger.warning(
+                f"[{self.name}] Type error in comparison: {e} "
+                f"(actual={type(actual)}, expected={type(expected)})"
+            )
+            return False
+    
+    def update(self) -> Status:
+        """
+        Read the property and compare using the configured operator.
+        
+        Returns:
+            Status.SUCCESS if the comparison matches (or doesn't match if negate=True)
+            Status.FAILURE if the comparison fails or property cannot be read
+        """
+        logger.debug(
+            f"[{self.name}] Checking property with operator {self.operator.value}: "
+            f"{self.property_url}"
+        )
+        
+        try:
+            response = self._http_client.get(self.property_url)
+            
+            if not response.is_success:
+                logger.warning(
+                    f"[{self.name}] Failed to read property: HTTP {response.status_code}"
+                )
+                return Status.FAILURE
+            
+            # Navigate to the target value
+            self._actual_value = self._navigate_value(response.body)
+            expected = self._get_expected_value()
+            
+            # Perform comparison with operator
+            self._comparison_result = self._compare(self._actual_value, expected)
+            
+            # Apply negation if configured
+            final_result = not self._comparison_result if self.negate else self._comparison_result
+            
+            logger.debug(
+                f"[{self.name}] Comparison: {self._actual_value} {self.operator.value} "
+                f"{expected} -> {self._comparison_result} (negate={self.negate}, final={final_result})"
+            )
+            
+            return Status.SUCCESS if final_result else Status.FAILURE
+            
+        except HTTPError as e:
+            logger.error(f"[{self.name}] HTTP error: {e.message}")
+            return Status.FAILURE

--- a/ami_agents/bt_planning/nodes/blackboard_keys.py
+++ b/ami_agents/bt_planning/nodes/blackboard_keys.py
@@ -1,0 +1,97 @@
+"""
+Blackboard Keys for Behavior Tree Affordance Nodes
+
+Defines standardized keys for sharing data between nodes via the py-trees blackboard.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BlackboardKeys:
+    """
+    Standardized blackboard key definitions for affordance nodes.
+    
+    The blackboard is used to share state between behavior tree nodes.
+    These keys provide a consistent interface for accessing:
+    - Last action results
+    - Property values
+    - Error information
+    - Request/response metadata
+    
+    Usage:
+        # Register keys on blackboard
+        blackboard = py_trees.blackboard.Client(name="MyNode")
+        blackboard.register_key(key=BlackboardKeys.LAST_ACTION_RESULT, access=py_trees.common.Access.WRITE)
+        
+        # Write data
+        blackboard.set(BlackboardKeys.LAST_ACTION_RESULT, {"status": "success"})
+    """
+    
+    # Action-related keys
+    LAST_ACTION_RESULT: str = "affordance/last_action_result"
+    LAST_ACTION_URL: str = "affordance/last_action_url"
+    LAST_ACTION_STATUS_CODE: str = "affordance/last_action_status_code"
+    LAST_ACTION_ERROR: str = "affordance/last_action_error"
+    
+    # Property-related keys
+    LAST_PROPERTY_VALUE: str = "affordance/last_property_value"
+    LAST_PROPERTY_URL: str = "affordance/last_property_url"
+    LAST_PROPERTY_STATUS_CODE: str = "affordance/last_property_status_code"
+    LAST_PROPERTY_ERROR: str = "affordance/last_property_error"
+    
+    # General metadata
+    LAST_REQUEST_TIMESTAMP: str = "affordance/last_request_timestamp"
+    LAST_RESPONSE_HEADERS: str = "affordance/last_response_headers"
+    
+    @classmethod
+    def property_value_key(cls, property_name: str) -> str:
+        """
+        Generate a namespaced key for a specific property value.
+        
+        Args:
+            property_name: The name of the property (e.g., "state", "brightness")
+            
+        Returns:
+            A namespaced blackboard key for the property value
+            
+        Example:
+            key = BlackboardKeys.property_value_key("brightness")
+            # Returns: "affordance/properties/brightness"
+        """
+        return f"affordance/properties/{property_name}"
+    
+    @classmethod
+    def artifact_property_key(cls, artifact_id: str, property_name: str) -> str:
+        """
+        Generate a fully namespaced key for an artifact's property.
+        
+        Args:
+            artifact_id: Unique identifier for the artifact
+            property_name: The name of the property
+            
+        Returns:
+            A fully namespaced blackboard key
+            
+        Example:
+            key = BlackboardKeys.artifact_property_key("balconyLight", "state")
+            # Returns: "affordance/artifacts/balconyLight/state"
+        """
+        return f"affordance/artifacts/{artifact_id}/{property_name}"
+    
+    @classmethod
+    def action_result_key(cls, action_name: str) -> str:
+        """
+        Generate a namespaced key for a specific action's result.
+        
+        Args:
+            action_name: The name of the action (e.g., "turnOn", "setColor")
+            
+        Returns:
+            A namespaced blackboard key for the action result
+            
+        Example:
+            key = BlackboardKeys.action_result_key("turnOn")
+            # Returns: "affordance/actions/turnOn/result"
+        """
+        return f"affordance/actions/{action_name}/result"

--- a/ami_agents/bt_planning/nodes/http_client.py
+++ b/ami_agents/bt_planning/nodes/http_client.py
@@ -1,0 +1,321 @@
+"""
+HTTP Client for Affordance Nodes
+
+Provides a wrapper around httpx for communicating with Thing Description endpoints.
+Supports synchronous operations with retry logic, timeouts, and error handling.
+"""
+
+import httpx
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPError(Exception):
+    """
+    Exception raised when an HTTP request fails.
+    
+    Attributes:
+        url: The URL that was requested
+        status_code: HTTP status code (if available)
+        message: Error description
+        response_body: Response body content (if available)
+    """
+    
+    def __init__(
+        self,
+        url: str,
+        status_code: Optional[int] = None,
+        message: str = "HTTP request failed",
+        response_body: Optional[str] = None
+    ):
+        self.url = url
+        self.status_code = status_code
+        self.message = message
+        self.response_body = response_body
+        super().__init__(f"{message} (URL: {url}, Status: {status_code})")
+
+
+@dataclass
+class HTTPClientConfig:
+    """
+    Configuration for HTTP client behavior.
+    
+    Attributes:
+        timeout: Request timeout in seconds
+        max_retries: Maximum number of retry attempts for failed requests
+        retry_on_status_codes: HTTP status codes that trigger a retry
+        default_headers: Headers to include in all requests
+        verify_ssl: Whether to verify SSL certificates (for HTTPS)
+    """
+    
+    timeout: float = 30.0
+    max_retries: int = 3
+    retry_on_status_codes: Tuple[int, ...] = (408, 429, 500, 502, 503, 504)
+    default_headers: Dict[str, str] = field(default_factory=lambda: {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+    })
+    verify_ssl: bool = True
+    
+    def __post_init__(self):
+        if self.timeout <= 0:
+            raise ValueError("timeout must be positive")
+        if self.max_retries < 0:
+            raise ValueError("max_retries must be non-negative")
+
+
+@dataclass
+class HTTPResponse:
+    """
+    Encapsulates an HTTP response.
+    
+    Attributes:
+        status_code: HTTP status code
+        body: Response body (parsed as JSON if possible, otherwise raw string)
+        headers: Response headers as a dictionary
+        url: The final URL (after any redirects)
+        elapsed_time: Time taken for the request in seconds
+    """
+    
+    status_code: int
+    body: Any
+    headers: Dict[str, str]
+    url: str
+    elapsed_time: float
+    
+    @property
+    def is_success(self) -> bool:
+        """Check if the response indicates success (2xx status code)."""
+        return 200 <= self.status_code < 300
+    
+    @property
+    def is_json(self) -> bool:
+        """Check if the response body is a parsed JSON object."""
+        return isinstance(self.body, (dict, list))
+
+
+class HTTPClient:
+    """
+    HTTP client wrapper around httpx for interacting with Thing Description endpoints.
+    
+    This client provides methods for making HTTP requests to action and property
+    affordance endpoints, with built-in retry logic, timeout handling, and
+    consistent error reporting.
+    
+    Expected response formats from simulators:
+    - Property reads (GET): JSON values (e.g., "on", 25, {"hand": "empty", "blocks": [...]})
+    - Action invocations (POST): {"status": "success", "message": "..."} on success
+    - Errors: {"error": "..."} or {"detail": "..."} with HTTP 4xx/5xx
+    
+    Example:
+        client = HTTPClient()
+        
+        # Invoke an action
+        response = client.post(
+            "http://localhost:8080/artifacts/light/turn_on",
+            payload={}
+        )
+        
+        # Read a property
+        response = client.get(
+            "http://localhost:8080/artifacts/light/properties/state"
+        )
+        print(response.body)  # "on" or {"hand": "empty", ...}
+    """
+    
+    def __init__(self, config: Optional[HTTPClientConfig] = None):
+        """
+        Initialize the HTTP client.
+        
+        Args:
+            config: Optional configuration. Uses defaults if not provided.
+        """
+        self.config = config or HTTPClientConfig()
+        self._session_headers: Dict[str, str] = {}
+        
+        # Create httpx transport with retries
+        transport = httpx.HTTPTransport(retries=self.config.max_retries)
+        
+        # Create httpx client
+        self._client = httpx.Client(
+            timeout=httpx.Timeout(self.config.timeout),
+            headers=self.config.default_headers,
+            transport=transport,
+            verify=self.config.verify_ssl,
+        )
+    
+    def set_session_header(self, key: str, value: str) -> None:
+        """
+        Set a header that will be included in all requests for this session.
+        
+        Args:
+            key: Header name
+            value: Header value
+        """
+        self._session_headers[key] = value
+        self._client.headers[key] = value
+    
+    def clear_session_headers(self) -> None:
+        """Clear all session-specific headers."""
+        for key in self._session_headers:
+            self._client.headers.pop(key, None)
+        self._session_headers.clear()
+    
+    def _convert_response(self, response: httpx.Response) -> HTTPResponse:
+        """Convert httpx response to our HTTPResponse format."""
+        # Try to parse JSON, fall back to text
+        try:
+            body = response.json()
+        except Exception:
+            body = response.text if response.text else None
+        
+        return HTTPResponse(
+            status_code=response.status_code,
+            body=body,
+            headers=dict(response.headers),
+            url=str(response.url),
+            elapsed_time=response.elapsed.total_seconds(),
+        )
+    
+    def _handle_error(self, e: Exception, url: str) -> None:
+        """Convert httpx exceptions to HTTPError."""
+        if isinstance(e, httpx.HTTPStatusError):
+            # Try to get error details from response body
+            try:
+                error_body = e.response.json()
+                error_msg = error_body.get("error") or error_body.get("detail") or str(error_body)
+            except Exception:
+                error_msg = e.response.text or str(e)
+            
+            raise HTTPError(
+                url=url,
+                status_code=e.response.status_code,
+                message=f"HTTP {e.response.status_code}: {error_msg}",
+                response_body=e.response.text,
+            )
+        elif isinstance(e, httpx.TimeoutException):
+            raise HTTPError(
+                url=url,
+                status_code=None,
+                message=f"Request timed out after {self.config.timeout}s",
+            )
+        elif isinstance(e, httpx.ConnectError):
+            raise HTTPError(
+                url=url,
+                status_code=None,
+                message=f"Connection failed: {str(e)}",
+            )
+        else:
+            raise HTTPError(
+                url=url,
+                status_code=None,
+                message=f"Request failed: {str(e)}",
+            )
+    
+    def get(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]] = None
+    ) -> HTTPResponse:
+        """
+        Make a GET request (used for reading property affordances).
+        
+        Args:
+            url: The URL to request
+            headers: Additional headers to include
+            
+        Returns:
+            HTTPResponse object with body containing the property value
+        """
+        try:
+            response = self._client.get(url, headers=headers)
+            response.raise_for_status()
+            return self._convert_response(response)
+        except Exception as e:
+            self._handle_error(e, url)
+    
+    def post(
+        self,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None
+    ) -> HTTPResponse:
+        """
+        Make a POST request (used for invoking action affordances).
+        
+        Args:
+            url: The URL to request
+            payload: Request body (will be JSON-encoded)
+            headers: Additional headers to include
+            
+        Returns:
+            HTTPResponse object with body containing {"status": "success", "message": "..."}
+        """
+        try:
+            response = self._client.post(url, json=payload or {}, headers=headers)
+            response.raise_for_status()
+            return self._convert_response(response)
+        except Exception as e:
+            self._handle_error(e, url)
+    
+    def put(
+        self,
+        url: str,
+        payload: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None
+    ) -> HTTPResponse:
+        """
+        Make a PUT request.
+        
+        Args:
+            url: The URL to request
+            payload: Request body (will be JSON-encoded)
+            headers: Additional headers to include
+            
+        Returns:
+            HTTPResponse object
+        """
+        try:
+            response = self._client.put(url, json=payload or {}, headers=headers)
+            response.raise_for_status()
+            return self._convert_response(response)
+        except Exception as e:
+            self._handle_error(e, url)
+    
+    def delete(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]] = None
+    ) -> HTTPResponse:
+        """
+        Make a DELETE request.
+        
+        Args:
+            url: The URL to request
+            headers: Additional headers to include
+            
+        Returns:
+            HTTPResponse object
+        """
+        try:
+            response = self._client.delete(url, headers=headers)
+            response.raise_for_status()
+            return self._convert_response(response)
+        except Exception as e:
+            self._handle_error(e, url)
+    
+    def close(self) -> None:
+        """Close the underlying httpx client."""
+        self._client.close()
+    
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit - close the client."""
+        self.close()
+        return False

--- a/ami_agents/bt_planning/planning/__init__.py
+++ b/ami_agents/bt_planning/planning/__init__.py
@@ -1,0 +1,12 @@
+"""
+BT planning module - JSON IR generation via LLM.
+"""
+
+from .schema import TREE_PARAMETER_SCHEMA, GENERATE_BT_TOOL
+from .bt_planner import AsyncBTPlanner
+
+__all__ = [
+    "TREE_PARAMETER_SCHEMA",
+    "GENERATE_BT_TOOL",
+    "AsyncBTPlanner",
+]

--- a/ami_agents/bt_planning/planning/bt_planner.py
+++ b/ami_agents/bt_planning/planning/bt_planner.py
@@ -1,0 +1,342 @@
+"""
+Async BehaviorTree Planner
+
+Generates JSON IR behavior trees using async OpenAI API,
+adapted for the SPADE multi-agent context in the AAMAS 2026 demo.
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+from openai import AsyncOpenAI
+
+from .schema import GENERATE_BT_TOOL
+from .prompts import (
+    BT_PLANNING_SYSTEM_PROMPT,
+    format_capability_context,
+    format_signifier_hints,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncBTPlanner:
+    """
+    Generates JSON IR behavior trees using async OpenAI API.
+
+    This planner:
+    1. Formats environment context (affordances + state + signifier hints)
+    2. Calls the LLM with the generate_behavior_tree tool
+    3. Validates the response tree structure
+    4. Returns the JSON IR dict
+
+    Usage:
+        planner = AsyncBTPlanner()
+        result = await planner.generate_bt(
+            intents=["turn on the light", "open the blinds"],
+            affordances=[...],
+            state={...},
+            signifier_hints={...},
+            client=async_openai_client,
+            model="o3",
+        )
+    """
+
+    def __init__(self, max_attempts: int = 3):
+        """
+        Args:
+            max_attempts: Maximum LLM call attempts for validation retries
+        """
+        self.max_attempts = max_attempts
+
+    async def generate_bt(
+        self,
+        intents: list[str],
+        affordances: list[dict],
+        state: Optional[dict] = None,
+        signifier_hints: Optional[dict] = None,
+        client: Optional[AsyncOpenAI] = None,
+        model: str = "o3",
+        temperature: Optional[float] = None,
+        reasoning_effort: Optional[str] = None,
+        max_completion_tokens: Optional[int] = None,
+    ) -> dict:
+        """
+        Generate a JSON IR behavior tree.
+
+        Args:
+            intents: List of user intents to satisfy
+            affordances: List of available affordance dicts
+            state: Optional current state dict
+            signifier_hints: Optional signifier match data for context injection
+            client: AsyncOpenAI client
+            model: Model name (e.g., "o3", "gpt-4o")
+            temperature: Optional temperature override
+            reasoning_effort: Optional reasoning effort ("low", "medium", "high")
+            max_completion_tokens: Optional max completion tokens
+
+        Returns:
+            Dict with keys: tree (JSON IR spec), explanation (str),
+            impossible (bool), intents (list)
+        """
+        if client is None:
+            raise ValueError("AsyncOpenAI client is required")
+
+        # Build the planning prompt
+        capability_context = format_capability_context(affordances, state)
+        sig_hints_text = format_signifier_hints(signifier_hints)
+
+        system_prompt = BT_PLANNING_SYSTEM_PROMPT.format(
+            capability_context=capability_context,
+            signifier_hints=sig_hints_text,
+        )
+
+        # Format user message with intents
+        user_message = self._format_user_message(intents)
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+
+        # Build API kwargs
+        api_kwargs = self._build_api_kwargs(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            reasoning_effort=reasoning_effort,
+            max_completion_tokens=max_completion_tokens,
+        )
+
+        # Retry loop for validation
+        last_explanation = ""
+        validation_errors: list[str] = []
+
+        for attempt in range(self.max_attempts):
+            try:
+                response = await client.chat.completions.create(**api_kwargs)
+            except Exception as e:
+                logger.error(f"LLM call failed: {e}")
+                return {
+                    "tree": {},
+                    "explanation": f"LLM call failed: {e}",
+                    "impossible": False,
+                    "intents": intents,
+                }
+
+            message = response.choices[0].message
+
+            # Append assistant message for potential retry
+            assistant_msg: dict[str, Any] = {"role": "assistant", "content": message.content}
+            if message.tool_calls:
+                assistant_msg["tool_calls"] = message.tool_calls
+            messages.append(assistant_msg)
+
+            if not message.tool_calls:
+                logger.warning("No tool call in response")
+                return {
+                    "tree": {},
+                    "explanation": f"Generation failed: {message.content}",
+                    "impossible": False,
+                    "intents": intents,
+                }
+
+            tool_call = message.tool_calls[0]
+            try:
+                args = json.loads(tool_call.function.arguments)
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse JSON: {e}")
+                return {
+                    "tree": {},
+                    "explanation": f"JSON parse error: {e}",
+                    "impossible": False,
+                    "intents": intents,
+                }
+
+            tree_spec = args.get("tree", {})
+            last_explanation = args.get("explanation", "")
+            impossible = args.get("impossible", False)
+
+            if impossible:
+                logger.info(f"Goal marked as impossible: {last_explanation}")
+                return {
+                    "tree": {},
+                    "explanation": last_explanation,
+                    "impossible": True,
+                    "intents": intents,
+                }
+
+            # Normalize tree (fill in missing optional fields like 'name')
+            tree_spec = self._normalize_tree(tree_spec)
+
+            # Validate
+            validation_errors = self._validate_tree(tree_spec)
+            if not validation_errors:
+                node_count = self._count_nodes(tree_spec)
+                logger.info(f"Generated JSON IR with {node_count} nodes")
+                return {
+                    "tree": tree_spec,
+                    "explanation": last_explanation,
+                    "impossible": False,
+                    "intents": intents,
+                }
+
+            logger.warning(
+                "Invalid tree spec (attempt %d/%d): %s",
+                attempt + 1,
+                self.max_attempts,
+                "; ".join(validation_errors),
+            )
+
+            # Provide feedback for retry
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": (
+                    "The previous behavior tree was invalid:\n- "
+                    + "\n- ".join(validation_errors)
+                    + "\nPlease call generate_behavior_tree again with a corrected, non-empty tree."
+                ),
+            })
+
+            # Update kwargs with new messages
+            api_kwargs["messages"] = messages
+
+        return {
+            "tree": {},
+            "explanation": "Generation failed: " + "; ".join(validation_errors),
+            "impossible": False,
+            "intents": intents,
+        }
+
+    def _format_user_message(self, intents: list[str]) -> str:
+        """Format the user message from intents."""
+        if len(intents) == 1:
+            return intents[0]
+        return (
+            "Please handle the following requests:\n"
+            + "\n".join(f"- {intent}" for intent in intents)
+        )
+
+    def _build_api_kwargs(
+        self,
+        model: str,
+        messages: list[dict],
+        temperature: Optional[float],
+        reasoning_effort: Optional[str],
+        max_completion_tokens: Optional[int],
+    ) -> dict:
+        """Build kwargs for the OpenAI API call."""
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "tools": [GENERATE_BT_TOOL],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "generate_behavior_tree"},
+            },
+        }
+
+        # Reasoning models (o-series) don't support temperature
+        is_reasoning = model.startswith("o")
+        if not is_reasoning and temperature is not None:
+            kwargs["temperature"] = temperature
+
+        if is_reasoning and reasoning_effort:
+            kwargs["reasoning_effort"] = reasoning_effort
+
+        if max_completion_tokens is not None:
+            kwargs["max_completion_tokens"] = max_completion_tokens
+
+        return kwargs
+
+    def _normalize_tree(self, spec: dict, _counter: list | None = None) -> dict:
+        """
+        Normalize a tree spec by filling in default values for optional fields.
+
+        LLMs (especially smaller models like gpt-4o-mini) often omit the 'name'
+        field. This method generates sensible defaults so validation passes.
+        """
+        if not isinstance(spec, dict) or not spec:
+            return spec
+
+        if _counter is None:
+            _counter = [0]
+
+        # Auto-generate name if missing
+        if not spec.get("name") or not isinstance(spec.get("name"), str):
+            node_type = spec.get("type", "node")
+            if node_type == "action":
+                url = spec.get("action_url", "")
+                action_name = url.rstrip("/").rsplit("/", 1)[-1] if url else "action"
+                spec["name"] = action_name.replace("_", " ").title().replace(" ", "")
+            elif node_type == "condition":
+                prop = spec.get("property_url", "")
+                prop_name = prop.rstrip("/").rsplit("/", 1)[-1] if prop else "check"
+                expected = spec.get("expected_value", "")
+                spec["name"] = f"Check{prop_name.title()}Is{expected}".replace(" ", "")
+            else:
+                _counter[0] += 1
+                spec["name"] = f"{node_type.title()}_{_counter[0]}"
+
+        # Recursively normalize children
+        children = spec.get("children")
+        if isinstance(children, list):
+            spec["children"] = [
+                self._normalize_tree(child, _counter) for child in children
+            ]
+
+        return spec
+
+    def _count_nodes(self, spec: dict) -> int:
+        """Count nodes in a tree spec."""
+        if not spec:
+            return 0
+        count = 1
+        for child in spec.get("children", []):
+            count += self._count_nodes(child)
+        return count
+
+    def _validate_tree(self, spec: dict, path: str = "tree") -> list[str]:
+        """Validate that the tree spec is non-empty and structurally sound."""
+        errors: list[str] = []
+
+        if not spec:
+            errors.append(f"{path}: tree is empty")
+            return errors
+
+        if not isinstance(spec, dict):
+            errors.append(f"{path}: expected object, got {type(spec).__name__}")
+            return errors
+
+        name = spec.get("name")
+        if not name or not isinstance(name, str):
+            errors.append(f"{path}: missing 'name'")
+
+        node_type = spec.get("type")
+        valid_types = {"sequence", "selector", "parallel", "action", "condition"}
+        if node_type not in valid_types:
+            errors.append(f"{path}: missing or invalid 'type'")
+
+        if node_type in {"sequence", "selector", "parallel"}:
+            children = spec.get("children")
+            if not isinstance(children, list) or not children:
+                errors.append(f"{path}: composite nodes require non-empty 'children'")
+            else:
+                for idx, child in enumerate(children):
+                    errors.extend(
+                        self._validate_tree(child, path=f"{path}.children[{idx}]")
+                    )
+        elif node_type == "action":
+            action_url = spec.get("action_url")
+            if not action_url or not isinstance(action_url, str):
+                errors.append(f"{path}: action nodes require 'action_url'")
+        elif node_type == "condition":
+            property_url = spec.get("property_url")
+            if not property_url or not isinstance(property_url, str):
+                errors.append(f"{path}: condition nodes require 'property_url'")
+            if "expected_value" not in spec:
+                errors.append(f"{path}: condition nodes require 'expected_value'")
+
+        return errors

--- a/ami_agents/bt_planning/planning/prompts.py
+++ b/ami_agents/bt_planning/planning/prompts.py
@@ -1,0 +1,164 @@
+"""
+Prompts for BehaviorTree planning with signifier hint injection.
+"""
+
+
+BT_PLANNING_SYSTEM_PROMPT = """\
+You are a behavior tree planning agent for smart environments.
+You generate executable behavior tree specifications in JSON format using the generate_behavior_tree tool.
+
+## Behavior Tree Node Types
+
+1. **sequence**: Executes children left-to-right. Fails on first failure. Use for ordered steps.
+2. **selector**: Tries children left-to-right. Succeeds on first success. Use for alternatives/fallbacks.
+3. **parallel**: Runs all children concurrently. Policy: "success_on_all" or "success_on_one".
+4. **action**: Leaf node that invokes an HTTP POST action affordance. Requires "action_url" and optional "parameters".
+5. **condition**: Leaf node that checks a property value via HTTP GET. Requires "property_url" and "expected_value". Optional "operator" (==, !=, >, <, >=, <=).
+
+## Common Patterns
+
+- **Idempotent action** (do only if not already done):
+  selector -> [condition (check if already in desired state), action (do it)]
+
+- **Sequential commands** (do in order):
+  sequence -> [action1, action2, action3]
+
+- **Independent commands** (do all, order doesn't matter):
+  parallel (success_on_all) -> [action1, action2, action3]
+
+## Environment Interaction
+
+- Actions are invoked via HTTP POST to action_url with JSON parameters
+- Properties are read via HTTP GET from property_url returning JSON values
+- All URLs come from the affordances list provided below
+
+## Rules
+
+- If a requested action is impossible (no matching affordance exists), set "impossible": true and explain why.
+- If partial actions are possible, generate a tree for the possible ones and explain what's missing.
+- Always use the exact action_url and property_url from the provided affordances.
+- Use appropriate BT control patterns based on command relationships.
+
+{signifier_hints}
+
+## Available Devices, Affordances, and Current State
+
+{capability_context}
+"""
+
+
+def format_capability_context(
+    affordances: list[dict],
+    state: dict | None = None,
+) -> str:
+    """
+    Format affordances and state into a context string for the planning prompt.
+
+    Handles both BT-repo field names (affordance_uri, artifact_uri) and
+    EnvExplorer field names (affordance_id, artifact_id, target).
+
+    Args:
+        affordances: List of affordance dicts from EnvExplorer
+        state: Optional state dict (artifact_uri -> properties)
+
+    Returns:
+        Formatted context string
+    """
+    lines = []
+
+    if affordances:
+        lines.append("### Affordances")
+        lines.append("Use the target URL as action_url (for action nodes) or property_url (for condition nodes).")
+        lines.append("")
+        for aff in affordances:
+            name = aff.get("action_name") or aff.get("name", "unknown")
+            # target is the callable URL (hctl:hasTarget) - use as action_url/property_url in BT nodes
+            target = aff.get("target") or aff.get("affordance_uri") or aff.get("href", "")
+            method = aff.get("method", "POST")
+            artifact = aff.get("artifact_id") or aff.get("artifact_uri", "")
+            input_schema = aff.get("input_schema")
+
+            lines.append(f"- **{name}** ({method} {target})")
+            if artifact:
+                lines.append(f"  Artifact: {artifact}")
+            if input_schema:
+                lines.append(f"  Input: {input_schema}")
+
+    if state:
+        lines.append("")
+        lines.append("### Current State")
+        # Handle both flat dict and nested {artifacts: {...}} structure
+        state_items = state
+        if isinstance(state, dict) and "artifacts" in state and isinstance(state["artifacts"], dict):
+            state_items = state["artifacts"]
+        if isinstance(state_items, dict):
+            for artifact_uri, props in state_items.items():
+                lines.append(f"- {artifact_uri}:")
+                if isinstance(props, dict):
+                    for prop_name, prop_val in props.items():
+                        lines.append(f"  - {prop_name}: {prop_val}")
+                else:
+                    lines.append(f"  {props}")
+
+    return "\n".join(lines) if lines else "No affordances available."
+
+
+def format_signifier_hints(signifier_matches: dict | None) -> str:
+    """
+    Format signifier matches as BT planning hints.
+
+    Args:
+        signifier_matches: Dict of intent -> match data from EnvExplorer/community
+
+    Returns:
+        Formatted hints string for the planning prompt
+    """
+    if not signifier_matches:
+        return ""
+
+    lines = ["## Past Successful Plans (Signifier Hints)", ""]
+    lines.append(
+        "Use these hints from previous interactions when planning. "
+        "If a hint's affordance exists in the affordances list, prefer it."
+    )
+    lines.append("")
+
+    for intent, match_data in signifier_matches.items():
+        if not isinstance(match_data, dict):
+            continue
+
+        finals = match_data.get("final_matches", [])
+        matches = match_data.get("matches", [])
+
+        if not finals and not matches:
+            lines.append(f"Intent: \"{intent}\" -- No prior experience.")
+            continue
+
+        # Find best match
+        best_match = None
+        if matches:
+            if finals:
+                for m in matches:
+                    if str(m.get("signifier_id")) == str(finals[0]):
+                        best_match = m
+                        break
+            if not best_match:
+                best_match = matches[0]
+
+        if best_match:
+            lines.append(f"Intent: \"{intent}\"")
+            aff_uri = best_match.get("affordance_uri", "")
+            if aff_uri:
+                lines.append(f"  Recommended action_url: {aff_uri}")
+            payload = best_match.get("payload_hint") or best_match.get("payload")
+            if payload:
+                lines.append(f"  Recommended parameters: {payload}")
+            similarity = best_match.get("intent_similarity", best_match.get("similarity"))
+            if similarity is not None:
+                lines.append(f"  Confidence: {similarity}")
+            source = best_match.get("source", "")
+            if source:
+                lines.append(f"  Source: {source}")
+            lines.append("")
+
+    return "\n".join(lines)

--- a/ami_agents/bt_planning/planning/schema.py
+++ b/ami_agents/bt_planning/planning/schema.py
@@ -1,0 +1,110 @@
+"""
+JSON IR schema and tool definition for BehaviorTree generation.
+
+Extracted from behaviortree-planning-for-ami-agents src/planning/output/json_ir.py.
+"""
+
+# JSON schema for behavior tree nodes
+TREE_PARAMETER_SCHEMA = {
+    "type": "object",
+    "minProperties": 1,
+    "properties": {
+        "name": {"type": "string"},
+        "type": {
+            "type": "string",
+            "enum": ["sequence", "selector", "parallel", "action", "condition"],
+        },
+        "children": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "object"},
+            "description": "Child nodes (required for sequence/selector/parallel).",
+        },
+        "policy": {
+            "type": "string",
+            "enum": ["success_on_all", "success_on_one"],
+            "description": "Policy for parallel nodes.",
+        },
+        "action_url": {
+            "type": "string",
+            "description": "HTTP POST URL to invoke for action nodes.",
+        },
+        "parameters": {
+            "type": "object",
+            "description": "Optional parameters for action nodes.",
+        },
+        "property_url": {
+            "type": "string",
+            "description": "HTTP GET URL to check for condition nodes.",
+        },
+        "expected_value": {
+            "description": "Expected value for condition nodes.",
+        },
+        "operator": {
+            "type": "string",
+            "enum": ["==", "!=", ">", "<", ">=", "<="],
+            "description": "Optional comparison operator for condition nodes.",
+        },
+        "value_path": {
+            "type": "string",
+            "description": "Optional JSON path for nested condition values.",
+        },
+    },
+    "required": ["name", "type"],
+    "oneOf": [
+        {
+            "title": "Sequence",
+            "properties": {"type": {"const": "sequence"}},
+            "required": ["children"],
+        },
+        {
+            "title": "Selector",
+            "properties": {"type": {"const": "selector"}},
+            "required": ["children"],
+        },
+        {
+            "title": "Parallel",
+            "properties": {"type": {"const": "parallel"}},
+            "required": ["children"],
+        },
+        {
+            "title": "Action",
+            "properties": {"type": {"const": "action"}},
+            "required": ["action_url"],
+        },
+        {
+            "title": "Condition",
+            "properties": {"type": {"const": "condition"}},
+            "required": ["property_url", "expected_value"],
+        },
+    ],
+    "description": (
+        "Behavior tree specification in JSON format; "
+        "DO NOT leave this empty if the goal is possible to achieve."
+    ),
+}
+
+
+# Tool definition for generating behavior trees
+GENERATE_BT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "generate_behavior_tree",
+        "description": "Generate a behavior tree specification for executing actions in a smart environment.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "tree": TREE_PARAMETER_SCHEMA,
+                "explanation": {
+                    "type": "string",
+                    "description": "Explanation of the plan",
+                },
+                "impossible": {
+                    "type": "boolean",
+                    "description": "If the goal is impossible to achieve, mark this as true",
+                },
+            },
+            "required": ["tree", "explanation", "impossible"],
+        },
+    },
+}

--- a/ami_agents/bt_planning/signifier_bridge.py
+++ b/ami_agents/bt_planning/signifier_bridge.py
@@ -1,0 +1,196 @@
+"""
+Signifier-BT Bridge
+
+Converts between BehaviorTree JSON IR nodes and the Signifier model
+used by the RD4 engine in EnvExplorer.
+
+Functions:
+- extract_signifiers_from_bt: Walk BT, collect action nodes as signifiers
+- build_bt_from_signifiers: Construct BT JSON IR from signifier matches (fast path)
+"""
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def extract_signifiers_from_bt(
+    tree_spec: dict,
+    intents: list[str],
+    was_successful: bool = True,
+    workspace_id: Optional[str] = None,
+) -> list[dict]:
+    """
+    Walk a BT JSON IR tree and extract signifier-worthy leaf nodes.
+
+    An ActionAffordanceNode maps to a signifier:
+      - intent: the intent this action serves
+      - affordance_uri: the action_url
+      - payload_hint: the parameters
+      - context: workspace_id, success status
+
+    Args:
+        tree_spec: JSON IR tree specification
+        intents: List of intents this tree was generated for
+        was_successful: Whether the BT execution succeeded
+        workspace_id: Optional workspace URI for context
+
+    Returns:
+        List of signifier dicts ready for recording
+    """
+    signifiers: list[dict] = []
+    _walk_tree(tree_spec, intents, was_successful, signifiers, workspace_id)
+    return signifiers
+
+
+def _walk_tree(
+    node: dict,
+    intents: list[str],
+    was_successful: bool,
+    signifiers: list[dict],
+    workspace_id: Optional[str],
+    depth: int = 0,
+) -> None:
+    """Recursively walk the tree and collect action nodes as signifiers."""
+    if not isinstance(node, dict):
+        return
+
+    node_type = node.get("type")
+
+    if node_type == "action":
+        action_url = node.get("action_url", "")
+        parameters = node.get("parameters", {})
+        node_name = node.get("name", "")
+
+        # Try to match this action to an intent
+        intent = _match_node_to_intent(node_name, action_url, intents)
+
+        signifiers.append({
+            "intent": intent,
+            "affordance_uri": action_url,
+            "action_name": _extract_action_name(action_url),
+            "payload_hint": parameters,
+            "workspace_id": workspace_id,
+            "was_successful": was_successful,
+            "source": "bt_execution",
+            "node_name": node_name,
+        })
+
+    elif node_type in ("sequence", "selector", "parallel"):
+        for child in node.get("children", []):
+            _walk_tree(child, intents, was_successful, signifiers, workspace_id, depth + 1)
+
+
+def _match_node_to_intent(
+    node_name: str,
+    action_url: str,
+    intents: list[str],
+) -> str:
+    """
+    Try to match a BT node to one of the intents.
+
+    Uses simple heuristic: check if intent keywords appear in the node name.
+    Falls back to the first intent if no match found.
+    """
+    node_name_lower = node_name.lower()
+    action_name = _extract_action_name(action_url).lower().replace("_", " ")
+
+    for intent in intents:
+        intent_lower = intent.lower()
+        # Check for keyword overlap
+        intent_words = set(intent_lower.split())
+        name_words = set(node_name_lower.split()) | set(action_name.split())
+
+        # If there's meaningful overlap (beyond stop words)
+        stop_words = {"the", "a", "an", "in", "on", "of", "to", "for", "is", "it"}
+        meaningful_overlap = (intent_words - stop_words) & (name_words - stop_words)
+        if meaningful_overlap:
+            return intent
+
+    # Default: assign to first intent
+    return intents[0] if intents else "unknown"
+
+
+def _extract_action_name(url: str) -> str:
+    """Extract the action name from a URL (last path segment)."""
+    return url.rstrip("/").rsplit("/", 1)[-1] if url else "unknown"
+
+
+def build_bt_from_signifiers(
+    signifier_matches: dict,
+    intents: list[str],
+) -> Optional[dict]:
+    """
+    Construct a BT JSON IR directly from signifier matches (fast path).
+
+    If ALL intents have matching signifiers, we can build a plan
+    without calling the LLM.
+
+    Args:
+        signifier_matches: Dict of intent -> match data
+        intents: List of intents to satisfy
+
+    Returns:
+        BT JSON IR dict if all intents have matches, None otherwise
+    """
+    if not signifier_matches or not intents:
+        return None
+
+    action_nodes: list[dict] = []
+
+    for intent in intents:
+        match_data = signifier_matches.get(intent)
+        if not isinstance(match_data, dict):
+            return None  # Not all intents matched
+
+        finals = match_data.get("final_matches", [])
+        matches = match_data.get("matches", [])
+
+        if not finals and not matches:
+            return None  # This intent has no match
+
+        # Find best match
+        best_match = None
+        if matches:
+            if finals:
+                for m in matches:
+                    if str(m.get("signifier_id")) == str(finals[0]):
+                        best_match = m
+                        break
+            if not best_match:
+                best_match = matches[0]
+
+        if not best_match:
+            return None
+
+        affordance_uri = best_match.get("affordance_uri", "")
+        if not affordance_uri:
+            return None
+
+        action_node = {
+            "name": f"action_{intent.replace(' ', '_')[:30]}",
+            "type": "action",
+            "action_url": affordance_uri,
+        }
+
+        payload = best_match.get("payload_hint") or best_match.get("payload")
+        if payload and isinstance(payload, dict):
+            action_node["parameters"] = payload
+
+        action_nodes.append(action_node)
+
+    if not action_nodes:
+        return None
+
+    # Single action: return directly
+    if len(action_nodes) == 1:
+        return action_nodes[0]
+
+    # Multiple actions: wrap in parallel (independent commands)
+    return {
+        "name": "SignifierReusePlan",
+        "type": "parallel",
+        "policy": "success_on_all",
+        "children": action_nodes,
+    }

--- a/ami_agents/config/agents.yaml
+++ b/ami_agents/config/agents.yaml
@@ -116,10 +116,16 @@ interaction_solver:
     # Context gathering
     context_gathering:
       from_env_explorer: true
-      from_community: false  # For future multi-environment support
+      from_community: true  # Cross-environment signifier sharing
       timeout: 10  # seconds
 
-    # LLM-based planning
+    # Community signifier API (cross-environment sharing)
+    community:
+      enabled: true
+      api_url: null  # Set via COMMUNITY_API_URL env var or override here
+      timeout: 5.0  # seconds for community API requests
+
+    # LLM-based planning (BT JSON IR generation)
     llm_planning:
       model: "gpt-4"
       temperature: 0.7
@@ -127,7 +133,7 @@ interaction_solver:
 
       # Behavior Tree generation
       output_format: "behavior_tree"
-      include_node_templates: true
+      max_planning_attempts: 3  # retries for BT generation
 
       # Node template features
       node_template_features:
@@ -193,3 +199,34 @@ logging:
 
   console_logging:
     enabled: true
+
+# Multi-Environment Demo Configuration
+# Each environment gets its own agent trio, sharing one community signifier API.
+environments:
+  lab308:
+    name: "Lab308 (Yggdrasil)"
+    yggdrasil_url: "http://localhost:8080"
+    agents:
+      user_assistant:
+        jid: "user_assistant_308@localhost"
+      env_explorer:
+        jid: "env_explorer_308@localhost"
+      interaction_solver:
+        jid: "interaction_solver_308@localhost"
+
+  homebench:
+    name: "HomeBench Home 17"
+    yggdrasil_url: "http://localhost:8090"
+    agents:
+      user_assistant:
+        jid: "user_assistant_hb@localhost"
+      env_explorer:
+        jid: "env_explorer_hb@localhost"
+      interaction_solver:
+        jid: "interaction_solver_hb@localhost"
+
+# Community Signifier API (shared service)
+community:
+  api_url: "http://localhost:8085"
+  # The RD4 signifier API running as a standalone service
+  # Both environments publish and query signifiers through this endpoint

--- a/ami_agents/shared/community/__init__.py
+++ b/ami_agents/shared/community/__init__.py
@@ -1,0 +1,7 @@
+"""
+Community signifier sharing module.
+"""
+
+from .community_client import CommunitySignifierClient
+
+__all__ = ["CommunitySignifierClient"]

--- a/ami_agents/shared/community/community_client.py
+++ b/ami_agents/shared/community/community_client.py
@@ -1,0 +1,144 @@
+"""
+Community Signifier Client
+
+HTTP client for querying the shared community signifier registry
+(the RD4 signifier API running as a standalone service).
+
+Used by InteractionSolver to discover cross-environment signifiers.
+"""
+
+import logging
+from typing import Any, Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class CommunitySignifierClient:
+    """
+    Client for querying the community signifier registry.
+
+    The community API is the RD4 signifier API (shared/memory/src/api/)
+    running as a shared service accessible by all environments.
+
+    Endpoints used:
+    - POST /matching/match - match signifiers by intent
+    - POST /signifiers - create/publish a signifier
+    - GET /signifiers - list all signifiers
+    """
+
+    def __init__(self, api_url: str, timeout: float = 10.0):
+        """
+        Args:
+            api_url: Base URL of the community signifier API
+            timeout: Request timeout in seconds
+        """
+        self.api_url = api_url.rstrip("/")
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+
+    async def match_signifiers(
+        self,
+        intent: str,
+        k: int = 5,
+        min_similarity: float = 0.5,
+    ) -> dict:
+        """
+        Query community for signifier matches.
+
+        Args:
+            intent: Natural language intent to match
+            k: Maximum number of matches to return
+            min_similarity: Minimum similarity threshold
+
+        Returns:
+            Dict with match results (matches, final_matches, etc.)
+        """
+        try:
+            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+                async with session.post(
+                    f"{self.api_url}/matching/match",
+                    json={
+                        "intent": intent,
+                        "k": k,
+                        "min_similarity": min_similarity,
+                    },
+                ) as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        logger.debug(
+                            f"Community match for '{intent}': "
+                            f"{len(data.get('matches', []))} matches"
+                        )
+                        return data
+                    else:
+                        logger.warning(
+                            f"Community match failed: HTTP {resp.status}"
+                        )
+                        return {}
+        except aiohttp.ClientError as e:
+            logger.warning(f"Community match request failed: {e}")
+            return {}
+        except Exception as e:
+            logger.warning(f"Unexpected error in community match: {e}")
+            return {}
+
+    async def publish_signifier(self, signifier_data: dict) -> bool:
+        """
+        Publish a signifier to the community.
+
+        Args:
+            signifier_data: Signifier dict to publish
+
+        Returns:
+            True if published successfully
+        """
+        try:
+            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+                async with session.post(
+                    f"{self.api_url}/signifiers",
+                    json=signifier_data,
+                ) as resp:
+                    if resp.status in (200, 201):
+                        logger.info(
+                            f"Published signifier to community: "
+                            f"{signifier_data.get('intent', 'unknown')}"
+                        )
+                        return True
+                    else:
+                        logger.warning(
+                            f"Failed to publish signifier: HTTP {resp.status}"
+                        )
+                        return False
+        except aiohttp.ClientError as e:
+            logger.warning(f"Community publish request failed: {e}")
+            return False
+        except Exception as e:
+            logger.warning(f"Unexpected error in community publish: {e}")
+            return False
+
+    async def list_signifiers(self) -> list[dict]:
+        """
+        List all signifiers in the community.
+
+        Returns:
+            List of signifier dicts
+        """
+        try:
+            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+                async with session.get(f"{self.api_url}/signifiers") as resp:
+                    if resp.status == 200:
+                        return await resp.json()
+                    return []
+        except Exception as e:
+            logger.warning(f"Community list request failed: {e}")
+            return []
+
+    async def health_check(self) -> bool:
+        """Check if the community API is reachable."""
+        try:
+            async with aiohttp.ClientSession(timeout=self.timeout) as session:
+                async with session.get(f"{self.api_url}/") as resp:
+                    return resp.status == 200
+        except Exception:
+            return False

--- a/ami_agents/shared/models/plan.py
+++ b/ami_agents/shared/models/plan.py
@@ -63,10 +63,31 @@ class NodeTemplate:
 
 @dataclass
 class BehaviorTreePlan:
-    """Represents a plan as a behavior tree."""
+    """
+    Represents a plan as a behavior tree.
+
+    Supports two representations:
+    - Legacy: NodeTemplate-based tree (root_node)
+    - BT JSON IR: Dict-based tree spec (tree_spec) used by IRExecutor
+    """
     plan_id: str
-    root_node: NodeTemplate
+    root_node: Optional[NodeTemplate] = None
+    tree_spec: Optional[Dict[str, Any]] = None  # BT JSON IR dict
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_json_ir(cls, plan_id: str, plan_dict: Dict[str, Any]) -> "BehaviorTreePlan":
+        """Create a BehaviorTreePlan from a BT JSON IR plan dict."""
+        return cls(
+            plan_id=plan_id,
+            tree_spec=plan_dict.get("tree"),
+            metadata={
+                "plan_type": plan_dict.get("plan_type", "behavior_tree"),
+                "explanation": plan_dict.get("explanation"),
+                "intents": plan_dict.get("intents", []),
+                "signifier_reuse": plan_dict.get("signifier_reuse", False),
+            },
+        )
 
     def get_all_signifiers(self) -> List[Dict[str, Any]]:
         """
@@ -75,12 +96,44 @@ class BehaviorTreePlan:
         Returns:
             List of signifiers with affordance usage information.
         """
-        # TODO: Implement recursive extraction of leaf action nodes
-        pass
+        signifiers: List[Dict[str, Any]] = []
+        tree = self.tree_spec or (self._node_to_dict(self.root_node) if self.root_node else None)
+        if not tree:
+            return signifiers
+        self._collect_action_nodes(tree, signifiers)
+        return signifiers
+
+    def _collect_action_nodes(self, node: Dict[str, Any], result: List[Dict[str, Any]]) -> None:
+        """Recursively collect action nodes from a BT JSON IR tree."""
+        if not isinstance(node, dict):
+            return
+        if node.get("type") == "action":
+            result.append({
+                "name": node.get("name", ""),
+                "action_url": node.get("action_url", ""),
+                "parameters": node.get("parameters", {}),
+            })
+        for child in node.get("children", []):
+            self._collect_action_nodes(child, result)
+
+    @staticmethod
+    def _node_to_dict(node: "NodeTemplate") -> Dict[str, Any]:
+        """Convert a NodeTemplate to a dict for uniform traversal."""
+        d: Dict[str, Any] = {
+            "type": node.node_type,
+            "name": node.name,
+        }
+        if node.affordance_uri:
+            d["action_url"] = node.affordance_uri
+        if node.action_params:
+            d["parameters"] = node.action_params
+        if node.children:
+            d["children"] = [BehaviorTreePlan._node_to_dict(c) for c in node.children]
+        return d
 
     def get_node_by_id(self, node_id: str) -> Optional[NodeTemplate]:
         """
-        Retrieve a node by its ID.
+        Retrieve a node by its ID (legacy NodeTemplate tree only).
 
         Args:
             node_id: The unique identifier of the node.
@@ -88,12 +141,23 @@ class BehaviorTreePlan:
         Returns:
             The node template if found, None otherwise.
         """
-        # TODO: Implement recursive node search
-        pass
+        if not self.root_node:
+            return None
+        return self._find_node(self.root_node, node_id)
+
+    @staticmethod
+    def _find_node(node: "NodeTemplate", node_id: str) -> Optional["NodeTemplate"]:
+        if node.node_id == node_id:
+            return node
+        for child in node.children:
+            found = BehaviorTreePlan._find_node(child, node_id)
+            if found:
+                return found
+        return None
 
     def update_node_status(self, node_id: str, status: NodeStatus) -> bool:
         """
-        Update the status of a node.
+        Update the status of a node (legacy NodeTemplate tree only).
 
         Args:
             node_id: The unique identifier of the node.
@@ -102,8 +166,11 @@ class BehaviorTreePlan:
         Returns:
             True if updated successfully, False otherwise.
         """
-        # TODO: Implement node status update
-        pass
+        node = self.get_node_by_id(node_id)
+        if node:
+            node.status = status
+            return True
+        return False
 
 
 @dataclass

--- a/ami_agents/shared/state_memory.py
+++ b/ami_agents/shared/state_memory.py
@@ -1,0 +1,69 @@
+"""
+Simple state memory cache for UserAssistant.
+
+Maps property_uri -> last_known_value so that state queries can be served
+from cache when the environment hasn't changed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("StateMemory")
+
+
+class StateMemoryCache:
+    """
+    In-memory cache for environment property values.
+
+    Used by UserAssistant to:
+    - Cache state query results (property_uri -> value)
+    - Serve repeated state lookups without re-querying EnvExplorer
+    - Update cached values after plan execution changes state
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, Any] = {}
+
+    def store(self, property_uri: str, value: Any) -> None:
+        """Store a property value."""
+        self._cache[property_uri] = value
+
+    def get(self, property_uri: str, default: Any = None) -> Any:
+        """Get a cached property value."""
+        return self._cache.get(property_uri, default)
+
+    def has(self, property_uri: str) -> bool:
+        """Check if a property is cached."""
+        return property_uri in self._cache
+
+    def clear(self) -> None:
+        """Clear all cached values."""
+        self._cache.clear()
+
+    def all(self) -> dict[str, Any]:
+        """Return a copy of all cached values."""
+        return dict(self._cache)
+
+    def store_bulk(self, state_data: dict) -> int:
+        """
+        Store multiple property values from a state response.
+
+        Accepts either:
+        - Flat dict: {property_uri: value, ...}
+        - Nested dict: {artifact_id: {property_uri: value, ...}, ...}
+
+        Returns the number of properties stored.
+        """
+        count = 0
+        for key, val in state_data.items():
+            if isinstance(val, dict):
+                # Nested: artifact_id -> {property_uri: value}
+                for prop_uri, prop_val in val.items():
+                    self._cache[prop_uri] = prop_val
+                    count += 1
+            else:
+                self._cache[key] = val
+                count += 1
+        return count

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,6 +24,7 @@ markers =
     asyncio: mark test as async
     integration: mark test as integration test
     unit: mark test as unit test
+    e2e: mark test as end-to-end test (requires running environments)
     slow: mark test as slow running
 
 # Logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,10 @@ spade-llm>=0.2.0
 # Web of Things / HTTP
 aiohttp>=3.10.4
 requests>=2.32.3
+httpx>=0.28.0
+
+# BehaviorTree execution
+py-trees>=2.4.0
 
 # LLM Integration
 openai>=2.8.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,240 @@
+"""
+Shared test fixtures for BT planning integration tests.
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ── Sample Data Fixtures ──────────────────────────────────────────────────────
+
+@pytest.fixture
+def sample_action_spec():
+    """A valid single-action BT JSON IR spec."""
+    return {
+        "name": "TurnOnLight",
+        "type": "action",
+        "action_url": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+        "parameters": {},
+    }
+
+
+@pytest.fixture
+def sample_condition_spec():
+    """A valid condition BT JSON IR spec."""
+    return {
+        "name": "IsLightOn",
+        "type": "condition",
+        "property_url": "http://localhost:8080/workspaces/lab308/artifacts/light308/properties/state",
+        "expected_value": "on",
+    }
+
+
+@pytest.fixture
+def sample_sequence_spec():
+    """A valid sequence BT JSON IR spec with multiple actions."""
+    return {
+        "name": "IncreaseLightSequence",
+        "type": "sequence",
+        "children": [
+            {
+                "name": "TurnOnLight",
+                "type": "action",
+                "action_url": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+                "parameters": {},
+            },
+            {
+                "name": "SetBrightness100",
+                "type": "action",
+                "action_url": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+                "parameters": {"brightness": 100},
+            },
+            {
+                "name": "OpenBlinds",
+                "type": "action",
+                "action_url": "http://localhost:8080/workspaces/lab308/artifacts/blinds308/set_position",
+                "parameters": {"position": 100},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_selector_spec():
+    """A valid selector BT JSON IR spec (idempotent pattern)."""
+    return {
+        "name": "EnsureLightOn",
+        "type": "selector",
+        "children": [
+            {
+                "name": "IsLightOn",
+                "type": "condition",
+                "property_url": "http://localhost:8080/workspaces/lab308/artifacts/light308/properties/state",
+                "expected_value": "on",
+            },
+            {
+                "name": "TurnOnLight",
+                "type": "action",
+                "action_url": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+                "parameters": {},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_parallel_spec():
+    """A valid parallel BT JSON IR spec."""
+    return {
+        "name": "ParallelActions",
+        "type": "parallel",
+        "policy": "success_on_all",
+        "children": [
+            {
+                "name": "TurnOnLight",
+                "type": "action",
+                "action_url": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+            },
+            {
+                "name": "OpenBlinds",
+                "type": "action",
+                "action_url": "http://localhost:8080/workspaces/lab308/artifacts/blinds308/set_position",
+                "parameters": {"position": 100},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_nested_spec():
+    """A deeply nested BT JSON IR spec."""
+    return {
+        "name": "Root",
+        "type": "sequence",
+        "children": [
+            {
+                "name": "HandleLight",
+                "type": "selector",
+                "children": [
+                    {
+                        "name": "IsLightOn",
+                        "type": "condition",
+                        "property_url": "http://localhost:8080/artifacts/light/properties/state",
+                        "expected_value": "on",
+                    },
+                    {
+                        "name": "TurnOnLight",
+                        "type": "action",
+                        "action_url": "http://localhost:8080/artifacts/light/turn_on",
+                    },
+                ],
+            },
+            {
+                "name": "SetBrightness",
+                "type": "action",
+                "action_url": "http://localhost:8080/artifacts/light/set_brightness",
+                "parameters": {"brightness": 100},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_affordances():
+    """Standard affordance list for Lab308."""
+    return [
+        {
+            "action_name": "turn_on",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "turn_off",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_off",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "set_brightness",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": {"type": "object", "properties": {"brightness": {"type": "integer", "minimum": 0, "maximum": 100}}},
+        },
+        {
+            "action_name": "set_position",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308/set_position",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308",
+            "method": "POST",
+            "input_schema": {"type": "object", "properties": {"position": {"type": "integer", "minimum": 0, "maximum": 100}}},
+        },
+    ]
+
+
+@pytest.fixture
+def sample_signifier_matches():
+    """Pre-built signifier match results."""
+    return {
+        "increase light level": {
+            "matches": [
+                {
+                    "signifier_id": "sig-001",
+                    "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+                    "payload_hint": {"brightness": 100},
+                    "intent_similarity": 0.92,
+                    "source": "lab308",
+                },
+            ],
+            "final_matches": ["sig-001"],
+        },
+    }
+
+
+@pytest.fixture
+def sample_state():
+    """Sample environment state."""
+    return {
+        "http://localhost:8080/workspaces/lab308/artifacts/light308": {
+            "state": "off",
+            "brightness": 0,
+        },
+        "http://localhost:8080/workspaces/lab308/artifacts/blinds308": {
+            "position": 0,
+        },
+    }
+
+
+# ── Mock Fixtures ──────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_http_response_success():
+    """Mock a successful HTTP response."""
+    from ami_agents.bt_planning.nodes.http_client import HTTPResponse
+
+    return HTTPResponse(
+        status_code=200,
+        body={"status": "success", "message": "Action completed"},
+        headers={"content-type": "application/json"},
+        url="http://localhost:8080/test",
+        elapsed_time=0.05,
+    )
+
+
+@pytest.fixture
+def mock_http_response_property():
+    """Mock a property read HTTP response."""
+    from ami_agents.bt_planning.nodes.http_client import HTTPResponse
+
+    return HTTPResponse(
+        status_code=200,
+        body="on",
+        headers={"content-type": "application/json"},
+        url="http://localhost:8080/test/properties/state",
+        elapsed_time=0.02,
+    )

--- a/tests/e2e/test_cross_env_sharing.py
+++ b/tests/e2e/test_cross_env_sharing.py
@@ -1,0 +1,260 @@
+"""
+E2E test: Cross-environment signifier sharing.
+
+Runs Lab308 scenario first, then HomeBench scenario.
+Verifies that signifiers from Lab308 influence HomeBench planning.
+
+Requirements:
+- OPENAI_API_KEY environment variable
+- Community signifier API running at http://localhost:8085 (optional for full flow)
+"""
+
+import json
+import os
+
+import pytest
+import pytest_asyncio
+
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY not set",
+    ),
+    pytest.mark.e2e,
+]
+
+
+@pytest_asyncio.fixture
+async def openai_client():
+    from openai import AsyncOpenAI
+
+    return AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+
+@pytest.fixture
+def planner():
+    from ami_agents.bt_planning.planning.bt_planner import AsyncBTPlanner
+
+    return AsyncBTPlanner(max_attempts=3)
+
+
+@pytest.fixture
+def lab308_affordances():
+    return [
+        {
+            "action_name": "turn_on",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+        },
+        {
+            "action_name": "set_brightness",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": {
+                "type": "object",
+                "properties": {"brightness": {"type": "integer", "minimum": 0, "maximum": 100}},
+            },
+        },
+        {
+            "action_name": "set_position",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308/set_position",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308",
+            "method": "POST",
+            "input_schema": {
+                "type": "object",
+                "properties": {"position": {"type": "integer", "minimum": 0, "maximum": 100}},
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def homebench_affordances():
+    return [
+        {
+            "action_name": "turn_on",
+            "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/turn_on",
+            "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+            "method": "POST",
+        },
+        {
+            "action_name": "turn_off",
+            "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/turn_off",
+            "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+            "method": "POST",
+        },
+        {
+            "action_name": "set_color",
+            "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/set_color",
+            "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+            "method": "POST",
+            "input_schema": {"type": "object", "properties": {"color": {"type": "string"}}},
+        },
+    ]
+
+
+class TestCrossEnvironmentSignifierSharing:
+    """
+    Full cross-environment scenario:
+    1. Lab308: "too dark" -> generate BT -> extract signifiers
+    2. HomeBench: inject Lab308 signifiers as hints -> generate BT
+    3. Verify HomeBench BT uses its own affordances guided by Lab308 hints
+    """
+
+    @pytest.mark.asyncio
+    async def test_lab308_then_homebench_sharing(
+        self, planner, openai_client, lab308_affordances, homebench_affordances
+    ):
+        """Full cross-environment flow."""
+        from ami_agents.bt_planning.signifier_bridge import extract_signifiers_from_bt
+
+        # --- Step 1: Lab308 scenario ---
+        lab308_state = {
+            "http://localhost:8080/workspaces/lab308/artifacts/light308": {
+                "state": "off",
+                "brightness": 0,
+            },
+        }
+
+        lab308_result = await planner.generate_bt(
+            intents=["turn on light308", "set light308 brightness to 100"],
+            affordances=lab308_affordances,
+            state=lab308_state,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        lab308_tree = lab308_result.get("tree", {})
+        assert lab308_tree, "Lab308 should produce a tree"
+        assert not lab308_result.get("impossible")
+
+        # Extract signifiers from Lab308 BT
+        lab308_signifiers = extract_signifiers_from_bt(
+            tree_spec=lab308_tree,
+            intents=lab308_result.get("intents", []),
+            was_successful=True,
+        )
+        assert len(lab308_signifiers) >= 1, "Should extract signifiers from Lab308 BT"
+
+        # --- Step 2: Convert Lab308 signifiers to hints for HomeBench ---
+        signifier_hints = {}
+        for sig in lab308_signifiers:
+            intent = sig.get("intent", "increase light level")
+            if intent not in signifier_hints:
+                signifier_hints[intent] = {"matches": [], "final_matches": []}
+            match = {
+                "signifier_id": sig.get("signifier_id", f"sig-lab308-{len(signifier_hints[intent]['matches'])}"),
+                "affordance_uri": sig.get("action_url") or sig.get("affordance_uri", ""),
+                "payload_hint": sig.get("parameters", {}),
+                "intent_similarity": 0.85,
+                "source": "lab308_community",
+            }
+            signifier_hints[intent]["matches"].append(match)
+            signifier_hints[intent]["final_matches"].append(match["signifier_id"])
+
+        # --- Step 3: HomeBench scenario with Lab308 hints ---
+        homebench_state = {
+            "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight": {
+                "state": "off",
+            },
+        }
+
+        homebench_result = await planner.generate_bt(
+            intents=["turn on studyRoomLight"],
+            affordances=homebench_affordances,
+            state=homebench_state,
+            signifier_hints=signifier_hints,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        homebench_tree = homebench_result.get("tree", {})
+        assert homebench_tree, "HomeBench should produce a tree"
+        assert not homebench_result.get("impossible")
+
+        # --- Step 4: Verify HomeBench uses its own URLs ---
+        valid_homebench_urls = {a["affordance_uri"] for a in homebench_affordances}
+
+        def collect_action_urls(node, urls=None):
+            if urls is None:
+                urls = []
+            if not isinstance(node, dict):
+                return urls
+            if node.get("type") == "action" and node.get("action_url"):
+                urls.append(node["action_url"])
+            for child in node.get("children", []):
+                collect_action_urls(child, urls)
+            return urls
+
+        homebench_urls = collect_action_urls(homebench_tree)
+        assert len(homebench_urls) >= 1, "HomeBench BT should have action nodes"
+
+        for url in homebench_urls:
+            assert url in valid_homebench_urls, (
+                f"HomeBench BT used URL {url} which is not in HomeBench affordances. "
+                f"Lab308 signifier hints should guide intent, not override URLs."
+            )
+
+        # --- Step 5: Verify both environments produced valid trees ---
+        lab308_errors = planner._validate_tree(lab308_tree)
+        homebench_errors = planner._validate_tree(homebench_tree)
+        assert lab308_errors == [], f"Lab308 validation errors: {lab308_errors}"
+        assert homebench_errors == [], f"HomeBench validation errors: {homebench_errors}"
+
+    @pytest.mark.asyncio
+    async def test_signifier_intent_transfer(
+        self, planner, openai_client, lab308_affordances, homebench_affordances
+    ):
+        """
+        Verify intent-level transfer: Lab308 has setBrightness, Home 17 has turnOn/setColor.
+        The signifier hint conveys 'increase light' concept even though affordances differ.
+        """
+        # Lab308 signifier for brightness adjustment
+        lab308_hints = {
+            "make it brighter": {
+                "matches": [
+                    {
+                        "signifier_id": "sig-brightness",
+                        "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+                        "payload_hint": {"brightness": 100},
+                        "intent_similarity": 0.9,
+                        "source": "lab308_community",
+                    },
+                ],
+                "final_matches": ["sig-brightness"],
+            },
+        }
+
+        # HomeBench has no setBrightness - only turnOn and setColor
+        result = await planner.generate_bt(
+            intents=["make it brighter in the study room"],
+            affordances=homebench_affordances,
+            signifier_hints=lab308_hints,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        tree = result.get("tree", {})
+        if not tree or result.get("impossible"):
+            # It's acceptable for the LLM to mark this as partially impossible
+            # since there's no brightness control in Home 17
+            return
+
+        # If a tree was generated, it should use HomeBench URLs
+        valid_urls = {a["affordance_uri"] for a in homebench_affordances}
+
+        def check_urls(node):
+            if not isinstance(node, dict):
+                return
+            if node.get("type") == "action":
+                url = node.get("action_url", "")
+                assert url in valid_urls, (
+                    f"URL {url} not in HomeBench affordances - "
+                    f"signifier hint should not inject Lab308 URLs"
+                )
+            for child in node.get("children", []):
+                check_urls(child)
+
+        check_urls(tree)

--- a/tests/e2e/test_demo_homebench.py
+++ b/tests/e2e/test_demo_homebench.py
@@ -1,0 +1,224 @@
+"""
+E2E test: HomeBench Home 17 demo scenario.
+
+Scenario: "I can't read anything at my desk" -> BT generated for Home 17 -> executed.
+
+Requirements:
+- OPENAI_API_KEY environment variable
+- HomeBench FastAPI simulator running at http://localhost:8090 (optional)
+"""
+
+import json
+import os
+
+import pytest
+import pytest_asyncio
+
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY not set",
+    ),
+    pytest.mark.e2e,
+]
+
+
+@pytest_asyncio.fixture
+async def openai_client():
+    from openai import AsyncOpenAI
+
+    return AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+
+@pytest.fixture
+def planner():
+    from ami_agents.bt_planning.planning.bt_planner import AsyncBTPlanner
+
+    return AsyncBTPlanner(max_attempts=3)
+
+
+@pytest.fixture
+def homebench_affordances():
+    """Affordances for HomeBench Home 17 study room."""
+    return [
+        {
+            "action_name": "turn_on",
+            "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/turn_on",
+            "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "turn_off",
+            "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/turn_off",
+            "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "set_color",
+            "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/set_color",
+            "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+            "method": "POST",
+            "input_schema": {
+                "type": "object",
+                "properties": {"color": {"type": "string"}},
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def homebench_state():
+    """Home 17 current state."""
+    return {
+        "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight": {
+            "state": "off",
+        },
+    }
+
+
+class TestHomeBenchImplicitCantRead:
+    """
+    Demo Scenario 2: User says "I can't read anything at my desk" in HomeBench Home 17.
+
+    Expected:
+    1. InteractionSolver generates BT for studyRoomLight
+    2. BT uses turn_on and/or set_color (no setBrightness in Home 17)
+    3. This demonstrates different affordances for similar intents
+    """
+
+    @pytest.mark.asyncio
+    async def test_bt_generation_for_cant_read(
+        self, planner, openai_client, homebench_affordances, homebench_state
+    ):
+        """Generate BT for implicit 'can't read' request."""
+        result = await planner.generate_bt(
+            intents=["turn on studyRoomLight"],
+            affordances=homebench_affordances,
+            state=homebench_state,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        assert not result.get("impossible"), f"Goal should be possible: {result.get('explanation')}"
+
+        tree = result.get("tree", {})
+        assert tree, "Tree should be non-empty"
+
+        validation_errors = planner._validate_tree(tree)
+        assert validation_errors == [], f"Validation errors: {validation_errors}"
+
+        # Verify URLs are from HomeBench, not Lab308
+        valid_urls = {a["affordance_uri"] for a in homebench_affordances}
+
+        def check_urls(node):
+            if not isinstance(node, dict):
+                return
+            if node.get("type") == "action":
+                url = node.get("action_url", "")
+                assert url in valid_urls, f"URL {url} not from HomeBench affordances"
+            for child in node.get("children", []):
+                check_urls(child)
+
+        check_urls(tree)
+
+    @pytest.mark.asyncio
+    async def test_bt_with_cross_env_signifier_hints(
+        self, planner, openai_client, homebench_affordances, homebench_state
+    ):
+        """
+        Generate BT for Home 17 with signifier hints from Lab308.
+
+        Lab308 had setBrightness, Home 17 only has turnOn/setColor.
+        The hint should guide intent-level transfer, not exact affordance copying.
+        """
+        lab308_signifier_hints = {
+            "increase light level": {
+                "matches": [
+                    {
+                        "signifier_id": "sig-lab308-brightness",
+                        "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+                        "payload_hint": {"brightness": 100},
+                        "intent_similarity": 0.88,
+                        "source": "lab308_community",
+                    },
+                    {
+                        "signifier_id": "sig-lab308-turnon",
+                        "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+                        "payload_hint": {},
+                        "intent_similarity": 0.92,
+                        "source": "lab308_community",
+                    },
+                ],
+                "final_matches": ["sig-lab308-turnon", "sig-lab308-brightness"],
+            },
+        }
+
+        result = await planner.generate_bt(
+            intents=["turn on studyRoomLight"],
+            affordances=homebench_affordances,
+            state=homebench_state,
+            signifier_hints=lab308_signifier_hints,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        tree = result.get("tree", {})
+        assert tree, "Should generate a tree even with cross-env hints"
+
+        # URLs must come from HomeBench, not Lab308
+        valid_urls = {a["affordance_uri"] for a in homebench_affordances}
+
+        def check_urls(node):
+            if not isinstance(node, dict):
+                return
+            if node.get("type") == "action":
+                url = node.get("action_url", "")
+                assert url in valid_urls, (
+                    f"URL {url} should be from HomeBench. "
+                    f"Lab308 hints should not override available affordances."
+                )
+            for child in node.get("children", []):
+                check_urls(child)
+
+        check_urls(tree)
+
+
+class TestHomeBenchSignifierExtraction:
+    """Test signifier extraction from HomeBench BTs."""
+
+    @pytest.mark.asyncio
+    async def test_extract_signifiers_homebench(
+        self, planner, openai_client, homebench_affordances, homebench_state
+    ):
+        """Signifiers extracted from HomeBench BT should reference Home 17 URLs."""
+        from ami_agents.bt_planning.signifier_bridge import extract_signifiers_from_bt
+
+        result = await planner.generate_bt(
+            intents=["turn on studyRoomLight"],
+            affordances=homebench_affordances,
+            state=homebench_state,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        tree = result.get("tree", {})
+        if not tree:
+            pytest.skip("No tree generated")
+
+        signifiers = extract_signifiers_from_bt(
+            tree_spec=tree,
+            intents=result.get("intents", []),
+            was_successful=True,
+        )
+
+        assert len(signifiers) >= 1
+
+        for sig in signifiers:
+            url = sig.get("action_url") or sig.get("affordance_uri", "")
+            assert "localhost:8090" in url or "home17" in url or "studyRoomLight" in url, (
+                f"Signifier URL should reference HomeBench: {url}"
+            )

--- a/tests/e2e/test_demo_lab308.py
+++ b/tests/e2e/test_demo_lab308.py
@@ -1,0 +1,193 @@
+"""
+E2E test: Lab308 demo scenario.
+
+Scenario: "It's too dark in here" -> BT generated -> BT executed -> signifiers recorded.
+
+Requirements:
+- OPENAI_API_KEY environment variable
+- Yggdrasil running at http://localhost:8080 with Lab308 workspace
+- Community signifier API running at http://localhost:8085 (optional)
+"""
+
+import json
+import os
+
+import pytest
+import pytest_asyncio
+
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY not set",
+    ),
+    pytest.mark.e2e,
+]
+
+
+@pytest_asyncio.fixture
+async def openai_client():
+    from openai import AsyncOpenAI
+
+    return AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+
+@pytest.fixture
+def planner():
+    from ami_agents.bt_planning.planning.bt_planner import AsyncBTPlanner
+
+    return AsyncBTPlanner(max_attempts=3)
+
+
+@pytest.fixture
+def lab308_affordances():
+    """Full Lab308 affordances (mirrors real Yggdrasil discovery)."""
+    return [
+        {
+            "action_name": "turn_on",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "turn_off",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_off",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "set_brightness",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": {
+                "type": "object",
+                "properties": {"brightness": {"type": "integer", "minimum": 0, "maximum": 100}},
+            },
+        },
+        {
+            "action_name": "set_position",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308/set_position",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308",
+            "method": "POST",
+            "input_schema": {
+                "type": "object",
+                "properties": {"position": {"type": "integer", "minimum": 0, "maximum": 100}},
+            },
+        },
+    ]
+
+
+@pytest.fixture
+def lab308_state():
+    """Lab308 current state (dark room)."""
+    return {
+        "http://localhost:8080/workspaces/lab308/artifacts/light308": {
+            "state": "off",
+            "brightness": 0,
+        },
+        "http://localhost:8080/workspaces/lab308/artifacts/blinds308": {
+            "position": 0,
+        },
+    }
+
+
+class TestLab308ImplicitToDark:
+    """
+    Demo Scenario 1: User says "It's too dark in here" in Lab308.
+
+    Expected:
+    1. InteractionSolver generates BT with light + blinds actions
+    2. BT execution succeeds (or validates if no live environment)
+    3. Signifiers extracted from executed BT
+    """
+
+    @pytest.mark.asyncio
+    async def test_bt_generation_for_dark_room(
+        self, planner, openai_client, lab308_affordances, lab308_state
+    ):
+        """Generate BT for implicit 'too dark' request."""
+        result = await planner.generate_bt(
+            intents=["turn on light308", "set light308 brightness to 100", "set blinds308 position to 100"],
+            affordances=lab308_affordances,
+            state=lab308_state,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        assert not result.get("impossible"), f"Goal should be possible: {result.get('explanation')}"
+
+        tree = result.get("tree", {})
+        assert tree, "Tree should be non-empty for a possible goal"
+
+        # Validate tree structure
+        validation_errors = planner._validate_tree(tree)
+        assert validation_errors == [], f"Validation errors: {validation_errors}"
+
+        # Count action nodes - should have at least 2 (light + blinds)
+        def count_actions(node):
+            if not isinstance(node, dict):
+                return 0
+            c = 1 if node.get("type") == "action" else 0
+            for child in node.get("children", []):
+                c += count_actions(child)
+            return c
+
+        action_count = count_actions(tree)
+        assert action_count >= 2, f"Expected at least 2 action nodes, got {action_count}"
+
+    @pytest.mark.asyncio
+    async def test_signifier_extraction_from_bt(
+        self, planner, openai_client, lab308_affordances, lab308_state
+    ):
+        """Extract signifiers from generated BT."""
+        from ami_agents.bt_planning.signifier_bridge import extract_signifiers_from_bt
+
+        result = await planner.generate_bt(
+            intents=["turn on light308", "set light308 brightness to 100"],
+            affordances=lab308_affordances,
+            state=lab308_state,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        tree = result.get("tree", {})
+        if not tree:
+            pytest.skip("No tree generated")
+
+        signifiers = extract_signifiers_from_bt(
+            tree_spec=tree,
+            intents=result.get("intents", []),
+            was_successful=True,
+        )
+
+        assert len(signifiers) >= 1, "Should extract at least 1 signifier"
+
+        for sig in signifiers:
+            assert "action_url" in sig or "affordance_uri" in sig, f"Signifier missing URL: {sig}"
+            assert "intent" in sig, f"Signifier missing intent: {sig}"
+
+    @pytest.mark.asyncio
+    async def test_bt_execution_dry_run(
+        self, planner, openai_client, lab308_affordances, lab308_state
+    ):
+        """Validate generated BT with IRExecutor (dry run, no live environment)."""
+        from ami_agents.bt_planning.execution.ir_executor import IRExecutor
+
+        result = await planner.generate_bt(
+            intents=["turn on light308"],
+            affordances=lab308_affordances,
+            state=lab308_state,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        tree = result.get("tree", {})
+        if not tree:
+            pytest.skip("No tree generated")
+
+        executor = IRExecutor(max_ticks=50)
+        validation_errors = executor.validate_tree(tree)
+        assert validation_errors == [], f"IRExecutor validation errors: {validation_errors}"

--- a/tests/integration/test_bt_planner_llm.py
+++ b/tests/integration/test_bt_planner_llm.py
@@ -1,0 +1,371 @@
+"""
+Integration tests for AsyncBTPlanner with real LLM.
+
+These tests require OPENAI_API_KEY to be set in the environment.
+They verify that the planner produces valid BT JSON IR from natural language intents.
+"""
+
+import json
+import os
+
+import pytest
+import pytest_asyncio
+
+from ami_agents.bt_planning.planning.bt_planner import AsyncBTPlanner
+from ami_agents.bt_planning.planning.schema import TREE_PARAMETER_SCHEMA
+
+# Skip all tests in this module if no API key
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set",
+)
+
+
+@pytest_asyncio.fixture
+async def openai_client():
+    """Real AsyncOpenAI client."""
+    from openai import AsyncOpenAI
+
+    return AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+
+@pytest.fixture
+def planner():
+    return AsyncBTPlanner(max_attempts=2)
+
+
+@pytest.fixture
+def lab308_affordances():
+    """Affordances for Lab308 environment."""
+    return [
+        {
+            "action_name": "turn_on",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "turn_off",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_off",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": None,
+        },
+        {
+            "action_name": "set_brightness",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/set_brightness",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308",
+            "method": "POST",
+            "input_schema": {
+                "type": "object",
+                "properties": {"brightness": {"type": "integer", "minimum": 0, "maximum": 100}},
+            },
+        },
+        {
+            "action_name": "set_position",
+            "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308/set_position",
+            "artifact_uri": "http://localhost:8080/workspaces/lab308/artifacts/blinds308",
+            "method": "POST",
+            "input_schema": {
+                "type": "object",
+                "properties": {"position": {"type": "integer", "minimum": 0, "maximum": 100}},
+            },
+        },
+    ]
+
+
+def _validate_tree_structure(tree: dict, errors: list, path: str = "tree") -> None:
+    """Recursively validate a BT JSON IR tree."""
+    assert isinstance(tree, dict), f"{path}: expected dict, got {type(tree).__name__}"
+    assert "name" in tree, f"{path}: missing 'name'"
+    assert "type" in tree, f"{path}: missing 'type'"
+
+    valid_types = {"sequence", "selector", "parallel", "action", "condition"}
+    assert tree["type"] in valid_types, f"{path}: invalid type '{tree['type']}'"
+
+    if tree["type"] in ("sequence", "selector", "parallel"):
+        assert "children" in tree, f"{path}: composite node missing 'children'"
+        assert isinstance(tree["children"], list), f"{path}: children must be a list"
+        assert len(tree["children"]) > 0, f"{path}: children must be non-empty"
+        for i, child in enumerate(tree["children"]):
+            _validate_tree_structure(child, errors, f"{path}.children[{i}]")
+
+    elif tree["type"] == "action":
+        assert "action_url" in tree, f"{path}: action missing 'action_url'"
+        assert isinstance(tree["action_url"], str), f"{path}: action_url must be string"
+
+    elif tree["type"] == "condition":
+        assert "property_url" in tree, f"{path}: condition missing 'property_url'"
+        assert "expected_value" in tree, f"{path}: condition missing 'expected_value'"
+
+
+class TestBTGeneration:
+    """Test BT generation with real LLM calls."""
+
+    @pytest.mark.asyncio
+    async def test_generate_bt_single_action(self, planner, openai_client, lab308_affordances):
+        """Single intent should produce a valid BT with at least one action node."""
+        result = await planner.generate_bt(
+            intents=["turn on light308"],
+            affordances=lab308_affordances,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        assert "tree" in result
+        assert "explanation" in result
+        assert result.get("impossible") is not True
+
+        tree = result["tree"]
+        assert isinstance(tree, dict)
+        assert tree  # non-empty
+
+        errors = []
+        _validate_tree_structure(tree, errors)
+
+    @pytest.mark.asyncio
+    async def test_generate_bt_multiple_actions(self, planner, openai_client, lab308_affordances):
+        """Multiple intents should produce a BT with multiple action nodes."""
+        result = await planner.generate_bt(
+            intents=["turn on light308", "set light308 brightness to 80"],
+            affordances=lab308_affordances,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        tree = result["tree"]
+        assert isinstance(tree, dict)
+        assert tree
+
+        # Count action nodes
+        def count_actions(node):
+            if not isinstance(node, dict):
+                return 0
+            c = 1 if node.get("type") == "action" else 0
+            for child in node.get("children", []):
+                c += count_actions(child)
+            return c
+
+        assert count_actions(tree) >= 2, "Should have at least 2 action nodes for 2 intents"
+
+    @pytest.mark.asyncio
+    async def test_generate_bt_impossible_request(self, planner, openai_client, lab308_affordances):
+        """Request for non-existent artifact should be marked impossible."""
+        result = await planner.generate_bt(
+            intents=["turn on the heater"],
+            affordances=lab308_affordances,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        # Either impossible=true or the tree is empty
+        if not result.get("impossible"):
+            # If LLM didn't mark impossible, tree should at minimum be empty or have no heater actions
+            tree = result.get("tree", {})
+            if tree:
+                # Check no action references a heater URL
+                def check_no_heater(node):
+                    if not isinstance(node, dict):
+                        return
+                    url = node.get("action_url", "")
+                    assert "heater" not in url.lower(), f"Found heater URL: {url}"
+                    for child in node.get("children", []):
+                        check_no_heater(child)
+
+                check_no_heater(tree)
+
+    @pytest.mark.asyncio
+    async def test_generated_bt_validates(self, planner, openai_client, lab308_affordances):
+        """Generated BT should pass the planner's own validation."""
+        result = await planner.generate_bt(
+            intents=["turn on light308", "open blinds308 fully"],
+            affordances=lab308_affordances,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        tree = result.get("tree", {})
+        if tree and not result.get("impossible"):
+            validation_errors = planner._validate_tree(tree)
+            assert validation_errors == [], f"Validation errors: {validation_errors}"
+
+    @pytest.mark.asyncio
+    async def test_generated_bt_uses_provided_urls(self, planner, openai_client, lab308_affordances):
+        """Generated BT action URLs should come from the provided affordances."""
+        result = await planner.generate_bt(
+            intents=["turn on light308"],
+            affordances=lab308_affordances,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        tree = result.get("tree", {})
+        if not tree or result.get("impossible"):
+            pytest.skip("No tree generated")
+
+        valid_urls = {a["affordance_uri"] for a in lab308_affordances}
+
+        def check_urls(node):
+            if not isinstance(node, dict):
+                return
+            if node.get("type") == "action":
+                url = node.get("action_url", "")
+                assert url in valid_urls, f"action_url {url} not in provided affordances"
+            for child in node.get("children", []):
+                check_urls(child)
+
+        check_urls(tree)
+
+
+class TestBTPlannerWithSignifiers:
+    """Test BT planning with signifier hints injected."""
+
+    @pytest.fixture
+    def signifier_hints(self):
+        return {
+            "turn on light308": {
+                "matches": [
+                    {
+                        "signifier_id": "sig-001",
+                        "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+                        "payload_hint": {},
+                        "intent_similarity": 0.95,
+                        "source": "lab308",
+                    },
+                ],
+                "final_matches": ["sig-001"],
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_signifier_hint_influences_plan(
+        self, planner, openai_client, lab308_affordances, signifier_hints
+    ):
+        """Providing signifier hints should produce a valid plan that uses the hinted affordance."""
+        result = await planner.generate_bt(
+            intents=["turn on light308"],
+            affordances=lab308_affordances,
+            signifier_hints=signifier_hints,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        tree = result.get("tree", {})
+        assert tree
+        assert not result.get("impossible")
+
+        # Verify the hinted URL was used
+        def find_urls(node, urls=None):
+            if urls is None:
+                urls = []
+            if not isinstance(node, dict):
+                return urls
+            if node.get("type") == "action" and node.get("action_url"):
+                urls.append(node["action_url"])
+            for child in node.get("children", []):
+                find_urls(child, urls)
+            return urls
+
+        urls = find_urls(tree)
+        hinted_url = "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on"
+        assert hinted_url in urls, f"Expected hinted URL in action nodes, got: {urls}"
+
+    @pytest.mark.asyncio
+    async def test_no_signifier_plans_independently(
+        self, planner, openai_client, lab308_affordances
+    ):
+        """Without signifier hints, planner should still generate a valid plan."""
+        result = await planner.generate_bt(
+            intents=["turn on light308"],
+            affordances=lab308_affordances,
+            signifier_hints=None,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        tree = result.get("tree", {})
+        assert tree
+        assert not result.get("impossible")
+
+    @pytest.mark.asyncio
+    async def test_signifier_from_different_env(
+        self, planner, openai_client
+    ):
+        """
+        Signifier hint from Lab308, affordances from HomeBench Home 17.
+        BT should use HomeBench URLs guided by Lab308 hint.
+        """
+        homebench_affordances = [
+            {
+                "action_name": "turn_on",
+                "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/turn_on",
+                "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+                "method": "POST",
+                "input_schema": None,
+            },
+            {
+                "action_name": "turn_off",
+                "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/turn_off",
+                "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+                "method": "POST",
+                "input_schema": None,
+            },
+            {
+                "action_name": "set_color",
+                "affordance_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight/set_color",
+                "artifact_uri": "http://localhost:8090/workspaces/home17/artifacts/studyRoomLight",
+                "method": "POST",
+                "input_schema": {"type": "object", "properties": {"color": {"type": "string"}}},
+            },
+        ]
+
+        # Signifier from Lab308 (different env, but similar intent)
+        lab308_hints = {
+            "increase light level": {
+                "matches": [
+                    {
+                        "signifier_id": "sig-lab308-01",
+                        "affordance_uri": "http://localhost:8080/workspaces/lab308/artifacts/light308/turn_on",
+                        "payload_hint": {},
+                        "intent_similarity": 0.9,
+                        "source": "lab308_community",
+                    },
+                ],
+                "final_matches": ["sig-lab308-01"],
+            },
+        }
+
+        result = await planner.generate_bt(
+            intents=["increase the light in the study room"],
+            affordances=homebench_affordances,
+            signifier_hints=lab308_hints,
+            client=openai_client,
+            model="gpt-4o-mini",
+        )
+
+        assert isinstance(result, dict)
+        tree = result.get("tree", {})
+        if not tree or result.get("impossible"):
+            pytest.skip("No tree generated for cross-env scenario")
+
+        # Verify URLs come from HomeBench, not Lab308
+        homebench_urls = {a["affordance_uri"] for a in homebench_affordances}
+
+        def check_urls(node):
+            if not isinstance(node, dict):
+                return
+            if node.get("type") == "action":
+                url = node.get("action_url", "")
+                assert url in homebench_urls, (
+                    f"action_url {url} should be from HomeBench, not Lab308"
+                )
+            for child in node.get("children", []):
+                check_urls(child)
+
+        check_urls(tree)

--- a/tests/unit/test_affordance_nodes.py
+++ b/tests/unit/test_affordance_nodes.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for custom py_trees affordance nodes with mocked HTTP.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from py_trees.common import Status
+
+from ami_agents.bt_planning.nodes.affordance_nodes import (
+    ActionAffordanceNode,
+    PropertyConditionNode,
+    ComparisonPropertyConditionNode,
+    ComparisonOperator,
+    ActionResult,
+    PropertyValue,
+)
+from ami_agents.bt_planning.nodes.http_client import HTTPResponse, HTTPError
+
+
+def _make_http_response(status_code=200, body=None):
+    """Helper to create mock HTTPResponse."""
+    return HTTPResponse(
+        status_code=status_code,
+        body=body or {"status": "success"},
+        headers={"content-type": "application/json"},
+        url="http://localhost:8080/test",
+        elapsed_time=0.05,
+    )
+
+
+class TestActionAffordanceNode:
+    """Tests for ActionAffordanceNode."""
+
+    def _make_node(self, **kwargs):
+        defaults = {
+            "name": "TestAction",
+            "action_url": "http://localhost:8080/artifacts/light/turn_on",
+        }
+        defaults.update(kwargs)
+        return ActionAffordanceNode(**defaults)
+
+    @patch.object(ActionAffordanceNode, "setup")
+    def test_action_node_success(self, mock_setup):
+        node = self._make_node()
+        node._http_client = MagicMock()
+        node._http_client.post.return_value = _make_http_response(200)
+        node.initialise()
+
+        status = node.update()
+        assert status == Status.SUCCESS
+        assert node.last_result is not None
+        assert node.last_result.success is True
+
+    @patch.object(ActionAffordanceNode, "setup")
+    def test_action_node_failure_status(self, mock_setup):
+        node = self._make_node()
+        node._http_client = MagicMock()
+        node._http_client.post.return_value = _make_http_response(500, {"error": "fail"})
+        node.initialise()
+
+        status = node.update()
+        assert status == Status.FAILURE
+
+    @patch.object(ActionAffordanceNode, "setup")
+    def test_action_node_http_error(self, mock_setup):
+        node = self._make_node()
+        node._http_client = MagicMock()
+        node._http_client.post.side_effect = HTTPError(
+            url="http://test", status_code=500, message="Server error"
+        )
+        node.initialise()
+
+        status = node.update()
+        assert status == Status.FAILURE
+        assert node.last_result.error_message == "Server error"
+
+    @patch.object(ActionAffordanceNode, "setup")
+    def test_action_node_with_parameters(self, mock_setup):
+        node = self._make_node(parameters={"brightness": 75})
+        node._http_client = MagicMock()
+        node._http_client.post.return_value = _make_http_response(200)
+        node.initialise()
+
+        node.update()
+        call_args = node._http_client.post.call_args
+        assert call_args[1]["payload"]["brightness"] == 75
+
+
+class TestPropertyConditionNode:
+    """Tests for PropertyConditionNode."""
+
+    def _make_node(self, **kwargs):
+        defaults = {
+            "name": "TestCondition",
+            "property_url": "http://localhost:8080/artifacts/light/properties/state",
+            "expected_value": "on",
+        }
+        defaults.update(kwargs)
+        return PropertyConditionNode(**defaults)
+
+    @patch.object(PropertyConditionNode, "setup")
+    def test_condition_matches(self, mock_setup):
+        node = self._make_node(expected_value="on")
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, "on")
+        node.initialise()
+
+        status = node.update()
+        assert status == Status.SUCCESS
+
+    @patch.object(PropertyConditionNode, "setup")
+    def test_condition_mismatch(self, mock_setup):
+        node = self._make_node(expected_value="on")
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, "off")
+        node.initialise()
+
+        status = node.update()
+        assert status == Status.FAILURE
+
+    @patch.object(PropertyConditionNode, "setup")
+    def test_condition_http_error(self, mock_setup):
+        node = self._make_node()
+        node._http_client = MagicMock()
+        node._http_client.get.side_effect = HTTPError(
+            url="http://test", status_code=500, message="Error"
+        )
+        node.initialise()
+
+        status = node.update()
+        assert status == Status.FAILURE
+
+    @patch.object(PropertyConditionNode, "setup")
+    def test_condition_with_value_path(self, mock_setup):
+        node = self._make_node(
+            expected_value="empty",
+            value_path=["hand"],
+        )
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(
+            200, {"hand": "empty", "blocks": ["a", "b"]}
+        )
+        node.initialise()
+
+        status = node.update()
+        assert status == Status.SUCCESS
+
+
+class TestComparisonPropertyConditionNode:
+    """Tests for ComparisonPropertyConditionNode."""
+
+    def _make_node(self, **kwargs):
+        defaults = {
+            "name": "TestComparison",
+            "property_url": "http://localhost:8080/props/temp",
+            "expected_value": 25,
+            "operator": ComparisonOperator.GREATER_THAN,
+        }
+        defaults.update(kwargs)
+        return ComparisonPropertyConditionNode(**defaults)
+
+    @patch.object(ComparisonPropertyConditionNode, "setup")
+    def test_greater_than_true(self, mock_setup):
+        node = self._make_node(expected_value=25, operator=ComparisonOperator.GREATER_THAN)
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, 30)
+        node.initialise()
+
+        assert node.update() == Status.SUCCESS
+
+    @patch.object(ComparisonPropertyConditionNode, "setup")
+    def test_greater_than_false(self, mock_setup):
+        node = self._make_node(expected_value=25, operator=ComparisonOperator.GREATER_THAN)
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, 20)
+        node.initialise()
+
+        assert node.update() == Status.FAILURE
+
+    @patch.object(ComparisonPropertyConditionNode, "setup")
+    def test_less_than(self, mock_setup):
+        node = self._make_node(expected_value=25, operator=ComparisonOperator.LESS_THAN)
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, 20)
+        node.initialise()
+
+        assert node.update() == Status.SUCCESS
+
+    @patch.object(ComparisonPropertyConditionNode, "setup")
+    def test_not_equal(self, mock_setup):
+        node = self._make_node(expected_value="off", operator=ComparisonOperator.NOT_EQUAL)
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, "on")
+        node.initialise()
+
+        assert node.update() == Status.SUCCESS
+
+    @patch.object(ComparisonPropertyConditionNode, "setup")
+    def test_in_operator(self, mock_setup):
+        node = self._make_node(
+            expected_value=["cool", "auto"],
+            operator=ComparisonOperator.IN,
+        )
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, "cool")
+        node.initialise()
+
+        assert node.update() == Status.SUCCESS
+
+    @patch.object(ComparisonPropertyConditionNode, "setup")
+    def test_greater_equal(self, mock_setup):
+        node = self._make_node(expected_value=25, operator=ComparisonOperator.GREATER_THAN_OR_EQUAL)
+        node._http_client = MagicMock()
+        node._http_client.get.return_value = _make_http_response(200, 25)
+        node.initialise()
+
+        assert node.update() == Status.SUCCESS

--- a/tests/unit/test_bt_schema.py
+++ b/tests/unit/test_bt_schema.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for BT JSON IR schema validation.
+"""
+
+import pytest
+
+from ami_agents.bt_planning.execution.ir_executor import IRExecutor
+
+
+@pytest.fixture
+def executor():
+    return IRExecutor(max_ticks=5)
+
+
+class TestSchemaValidation:
+    """Tests for IRExecutor._validate_tree()."""
+
+    def test_valid_sequence_tree(self, executor, sample_sequence_spec):
+        errors = executor.validate_tree(sample_sequence_spec)
+        assert errors == []
+
+    def test_valid_selector_tree(self, executor, sample_selector_spec):
+        errors = executor.validate_tree(sample_selector_spec)
+        assert errors == []
+
+    def test_valid_parallel_tree(self, executor, sample_parallel_spec):
+        errors = executor.validate_tree(sample_parallel_spec)
+        assert errors == []
+
+    def test_valid_action_with_params(self, executor):
+        spec = {
+            "name": "SetBrightness",
+            "type": "action",
+            "action_url": "http://localhost:8080/set_brightness",
+            "parameters": {"brightness": 75},
+        }
+        errors = executor.validate_tree(spec)
+        assert errors == []
+
+    def test_valid_condition(self, executor, sample_condition_spec):
+        errors = executor.validate_tree(sample_condition_spec)
+        assert errors == []
+
+    def test_valid_nested_tree(self, executor, sample_nested_spec):
+        errors = executor.validate_tree(sample_nested_spec)
+        assert errors == []
+
+    def test_invalid_empty_tree(self, executor):
+        errors = executor.validate_tree({})
+        assert len(errors) > 0
+        assert any("empty" in e for e in errors)
+
+    def test_invalid_missing_type(self, executor):
+        spec = {"name": "NoType"}
+        errors = executor.validate_tree(spec)
+        assert any("type" in e for e in errors)
+
+    def test_invalid_unknown_type(self, executor):
+        spec = {"name": "BadType", "type": "banana"}
+        errors = executor.validate_tree(spec)
+        assert any("type" in e for e in errors)
+
+    def test_invalid_action_missing_url(self, executor):
+        spec = {"name": "NoUrl", "type": "action"}
+        errors = executor.validate_tree(spec)
+        assert any("action_url" in e for e in errors)
+
+    def test_invalid_condition_missing_property_url(self, executor):
+        spec = {"name": "NoPropUrl", "type": "condition", "expected_value": "on"}
+        errors = executor.validate_tree(spec)
+        assert any("property_url" in e for e in errors)
+
+    def test_invalid_condition_missing_expected_value(self, executor):
+        spec = {
+            "name": "NoExpected",
+            "type": "condition",
+            "property_url": "http://localhost:8080/props/state",
+        }
+        errors = executor.validate_tree(spec)
+        assert any("expected_value" in e for e in errors)
+
+    def test_invalid_sequence_empty_children(self, executor):
+        spec = {"name": "EmptySeq", "type": "sequence", "children": []}
+        errors = executor.validate_tree(spec)
+        assert any("children" in e for e in errors)
+
+    def test_invalid_sequence_no_children(self, executor):
+        spec = {"name": "NoChildren", "type": "sequence"}
+        errors = executor.validate_tree(spec)
+        assert any("children" in e for e in errors)
+
+    def test_invalid_nested_child(self, executor):
+        spec = {
+            "name": "Root",
+            "type": "sequence",
+            "children": [
+                {"name": "Bad", "type": "action"},  # Missing action_url
+            ],
+        }
+        errors = executor.validate_tree(spec)
+        assert any("action_url" in e for e in errors)
+
+    def test_invalid_not_dict(self, executor):
+        errors = executor.validate_tree("not a dict")
+        assert len(errors) > 0

--- a/tests/unit/test_community_client.py
+++ b/tests/unit/test_community_client.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for CommunitySignifierClient with mocked HTTP.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from aiohttp import ClientError
+
+from ami_agents.shared.community.community_client import CommunitySignifierClient
+
+
+@pytest.fixture
+def client():
+    return CommunitySignifierClient(api_url="http://localhost:9000")
+
+
+class TestMatchSignifiers:
+    """Tests for CommunitySignifierClient.match_signifiers()."""
+
+    @pytest.mark.asyncio
+    async def test_match_success(self, client):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={
+            "matches": [
+                {"signifier_id": "sig-001", "affordance_uri": "http://test/turn_on", "intent_similarity": 0.9}
+            ],
+            "final_matches": ["sig-001"],
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await client.match_signifiers("increase light")
+
+        assert "matches" in result
+        assert len(result["matches"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_match_empty(self, client):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"matches": [], "final_matches": []})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await client.match_signifiers("unknown intent")
+
+        assert result.get("matches", []) == []
+
+    @pytest.mark.asyncio
+    async def test_match_server_error(self, client):
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await client.match_signifiers("test")
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_match_connection_error(self, client):
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=ClientError("Connection refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await client.match_signifiers("test")
+
+        assert result == {}
+
+
+class TestPublishSignifier:
+    """Tests for CommunitySignifierClient.publish_signifier()."""
+
+    @pytest.mark.asyncio
+    async def test_publish_success(self, client):
+        mock_resp = AsyncMock()
+        mock_resp.status = 201
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await client.publish_signifier({"intent": "turn on light"})
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_publish_failure(self, client):
+        mock_resp = AsyncMock()
+        mock_resp.status = 400
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await client.publish_signifier({"intent": "test"})
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_publish_connection_error(self, client):
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=ClientError("fail"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = await client.publish_signifier({"intent": "test"})
+
+        assert result is False

--- a/tests/unit/test_ir_executor.py
+++ b/tests/unit/test_ir_executor.py
@@ -1,0 +1,136 @@
+"""
+Unit tests for IRExecutor - compilation and execution with mocked HTTP.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+import py_trees
+from py_trees.common import Status
+
+from ami_agents.bt_planning.execution.ir_executor import IRExecutor
+from ami_agents.bt_planning.execution.base import ExecutionResult
+from ami_agents.bt_planning.nodes.affordance_nodes import (
+    ActionAffordanceNode,
+    PropertyConditionNode,
+    ComparisonPropertyConditionNode,
+)
+
+
+@pytest.fixture
+def executor():
+    return IRExecutor(max_ticks=10)
+
+
+class TestCompilation:
+    """Tests for IRExecutor._compile()."""
+
+    def test_compile_sequence_node(self, executor, sample_sequence_spec):
+        tree = executor._compile(sample_sequence_spec)
+        assert isinstance(tree, py_trees.composites.Sequence)
+        assert tree.name == "IncreaseLightSequence"
+        assert len(tree.children) == 3
+
+    def test_compile_selector_node(self, executor, sample_selector_spec):
+        tree = executor._compile(sample_selector_spec)
+        assert isinstance(tree, py_trees.composites.Selector)
+        assert tree.name == "EnsureLightOn"
+        assert len(tree.children) == 2
+
+    def test_compile_parallel_node(self, executor, sample_parallel_spec):
+        tree = executor._compile(sample_parallel_spec)
+        assert isinstance(tree, py_trees.composites.Parallel)
+        assert tree.name == "ParallelActions"
+        assert len(tree.children) == 2
+
+    def test_compile_action_node(self, executor, sample_action_spec):
+        tree = executor._compile(sample_action_spec)
+        assert isinstance(tree, ActionAffordanceNode)
+        assert tree.name == "TurnOnLight"
+        assert tree.action_url.endswith("/turn_on")
+
+    def test_compile_condition_node(self, executor, sample_condition_spec):
+        tree = executor._compile(sample_condition_spec)
+        assert isinstance(tree, PropertyConditionNode)
+        assert tree.name == "IsLightOn"
+        assert tree.expected_value == "on"
+
+    def test_compile_condition_with_operator(self, executor):
+        spec = {
+            "name": "TempCheck",
+            "type": "condition",
+            "property_url": "http://localhost:8080/props/temp",
+            "expected_value": 25,
+            "operator": ">",
+        }
+        tree = executor._compile(spec)
+        assert isinstance(tree, ComparisonPropertyConditionNode)
+
+    def test_compile_nested_tree(self, executor, sample_nested_spec):
+        tree = executor._compile(sample_nested_spec)
+        assert isinstance(tree, py_trees.composites.Sequence)
+        assert len(tree.children) == 2
+        assert isinstance(tree.children[0], py_trees.composites.Selector)
+        assert isinstance(tree.children[1], ActionAffordanceNode)
+
+    def test_compile_unknown_type_raises(self, executor):
+        spec = {"name": "Bad", "type": "banana"}
+        with pytest.raises(ValueError, match="Unknown node type"):
+            executor._compile(spec)
+
+    def test_compile_action_missing_url_raises(self, executor):
+        spec = {"name": "NoUrl", "type": "action"}
+        with pytest.raises(KeyError):
+            executor._compile(spec)
+
+
+class TestExecution:
+    """Tests for IRExecutor.execute_from_spec() with mocked HTTP."""
+
+    def test_execute_empty_spec(self, executor):
+        result = executor.execute_from_spec({})
+        assert result.success is True
+        assert result.ticks == 0
+        assert "No behavior tree" in result.final_status
+
+    def test_execute_none_spec(self, executor):
+        result = executor.execute_from_spec(None)
+        assert result.success is True
+        assert result.ticks == 0
+
+    @patch("ami_agents.bt_planning.nodes.affordance_nodes.ActionAffordanceNode.setup")
+    @patch("ami_agents.bt_planning.nodes.affordance_nodes.ActionAffordanceNode.update")
+    def test_execute_single_action_success(self, mock_update, mock_setup, executor, sample_action_spec):
+        mock_update.return_value = Status.SUCCESS
+        result = executor.execute_from_spec(sample_action_spec)
+        assert result.success is True
+        assert result.ticks == 1
+        assert result.final_status == "SUCCESS"
+
+    @patch("ami_agents.bt_planning.nodes.affordance_nodes.ActionAffordanceNode.setup")
+    @patch("ami_agents.bt_planning.nodes.affordance_nodes.ActionAffordanceNode.update")
+    def test_execute_single_action_failure(self, mock_update, mock_setup, executor, sample_action_spec):
+        mock_update.return_value = Status.FAILURE
+        result = executor.execute_from_spec(sample_action_spec)
+        assert result.success is False
+        assert result.final_status == "FAILURE"
+
+    def test_execute_invalid_spec_returns_error(self, executor):
+        spec = {"name": "Bad", "type": "nonexistent"}
+        result = executor.execute_from_spec(spec)
+        assert result.success is False
+        assert result.error is not None
+
+    def test_execution_result_to_dict(self):
+        result = ExecutionResult(
+            success=True,
+            tree_name="TestTree",
+            ticks=3,
+            final_status="SUCCESS",
+            tick_history=["RUNNING", "RUNNING", "SUCCESS"],
+        )
+        d = result.to_dict()
+        assert d["success"] is True
+        assert d["tree_name"] == "TestTree"
+        assert d["ticks"] == 3
+        assert len(d["tick_history"]) == 3

--- a/tests/unit/test_signifier_bridge.py
+++ b/tests/unit/test_signifier_bridge.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for BT <-> Signifier conversion (signifier_bridge).
+"""
+
+import pytest
+
+from ami_agents.bt_planning.signifier_bridge import (
+    extract_signifiers_from_bt,
+    build_bt_from_signifiers,
+)
+
+
+class TestExtractSignifiers:
+    """Tests for extract_signifiers_from_bt()."""
+
+    def test_extract_single_action(self, sample_action_spec):
+        sigs = extract_signifiers_from_bt(
+            tree_spec=sample_action_spec,
+            intents=["turn on the light"],
+        )
+        assert len(sigs) == 1
+        assert sigs[0]["affordance_uri"].endswith("/turn_on")
+        assert sigs[0]["intent"] == "turn on the light"
+        assert sigs[0]["source"] == "bt_execution"
+
+    def test_extract_multiple_actions(self, sample_sequence_spec):
+        sigs = extract_signifiers_from_bt(
+            tree_spec=sample_sequence_spec,
+            intents=["increase light level"],
+        )
+        assert len(sigs) == 3
+        urls = [s["affordance_uri"] for s in sigs]
+        assert any("turn_on" in u for u in urls)
+        assert any("set_brightness" in u for u in urls)
+        assert any("set_position" in u for u in urls)
+
+    def test_extract_nested_actions(self, sample_nested_spec):
+        sigs = extract_signifiers_from_bt(
+            tree_spec=sample_nested_spec,
+            intents=["turn on and brighten light"],
+        )
+        # selector > [condition, action] + action = 2 action nodes
+        assert len(sigs) == 2
+
+    def test_extract_skips_conditions(self, sample_selector_spec):
+        sigs = extract_signifiers_from_bt(
+            tree_spec=sample_selector_spec,
+            intents=["turn on the light"],
+        )
+        # selector > [condition, action] -> only 1 action extracted
+        assert len(sigs) == 1
+        assert sigs[0]["node_name"] == "TurnOnLight"
+
+    def test_extract_maps_intent(self):
+        spec = {
+            "name": "TurnOnLight",
+            "type": "action",
+            "action_url": "http://localhost/light/turn_on",
+        }
+        sigs = extract_signifiers_from_bt(
+            tree_spec=spec,
+            intents=["light turn on request"],
+        )
+        assert sigs[0]["intent"] == "light turn on request"
+
+    def test_extract_with_parameters(self):
+        spec = {
+            "name": "SetBrightness",
+            "type": "action",
+            "action_url": "http://localhost/light/set_brightness",
+            "parameters": {"brightness": 75},
+        }
+        sigs = extract_signifiers_from_bt(
+            tree_spec=spec,
+            intents=["set brightness"],
+        )
+        assert sigs[0]["payload_hint"] == {"brightness": 75}
+
+    def test_extract_from_empty_tree(self):
+        sigs = extract_signifiers_from_bt(tree_spec={}, intents=["test"])
+        assert sigs == []
+
+    def test_extract_workspace_id(self, sample_action_spec):
+        sigs = extract_signifiers_from_bt(
+            tree_spec=sample_action_spec,
+            intents=["test"],
+            workspace_id="http://localhost:8080/workspaces/lab308",
+        )
+        assert sigs[0]["workspace_id"] == "http://localhost:8080/workspaces/lab308"
+
+
+class TestBuildBTFromSignifiers:
+    """Tests for build_bt_from_signifiers()."""
+
+    def test_build_single_intent(self, sample_signifier_matches):
+        bt = build_bt_from_signifiers(
+            signifier_matches=sample_signifier_matches,
+            intents=["increase light level"],
+        )
+        assert bt is not None
+        assert bt["type"] == "action"
+        assert "set_brightness" in bt["action_url"]
+        assert bt["parameters"] == {"brightness": 100}
+
+    def test_build_multiple_intents(self):
+        matches = {
+            "turn on light": {
+                "matches": [{"signifier_id": "s1", "affordance_uri": "http://localhost/turn_on"}],
+                "final_matches": ["s1"],
+            },
+            "open blinds": {
+                "matches": [{"signifier_id": "s2", "affordance_uri": "http://localhost/set_position", "payload_hint": {"position": 100}}],
+                "final_matches": ["s2"],
+            },
+        }
+        bt = build_bt_from_signifiers(
+            signifier_matches=matches,
+            intents=["turn on light", "open blinds"],
+        )
+        assert bt is not None
+        assert bt["type"] == "parallel"
+        assert len(bt["children"]) == 2
+
+    def test_build_returns_none_if_no_matches(self):
+        bt = build_bt_from_signifiers(
+            signifier_matches={},
+            intents=["test"],
+        )
+        assert bt is None
+
+    def test_build_returns_none_if_partial_match(self, sample_signifier_matches):
+        bt = build_bt_from_signifiers(
+            signifier_matches=sample_signifier_matches,
+            intents=["increase light level", "unmatched intent"],
+        )
+        assert bt is None
+
+    def test_build_returns_none_if_empty_intents(self):
+        bt = build_bt_from_signifiers(
+            signifier_matches={"x": {"matches": [], "final_matches": []}},
+            intents=[],
+        )
+        assert bt is None
+
+    def test_build_returns_none_if_match_has_no_affordance_uri(self):
+        matches = {
+            "test": {
+                "matches": [{"signifier_id": "s1", "affordance_uri": ""}],
+                "final_matches": ["s1"],
+            },
+        }
+        bt = build_bt_from_signifiers(
+            signifier_matches=matches,
+            intents=["test"],
+        )
+        assert bt is None

--- a/tests/unit/test_state_memory.py
+++ b/tests/unit/test_state_memory.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for UserAssistant state memory cache.
+
+Tests the StateMemoryCache from ami_agents.shared.state_memory.
+"""
+
+import pytest
+
+from ami_agents.shared.state_memory import StateMemoryCache
+
+
+class TestStateMemoryCache:
+    """Tests for the state memory cache."""
+
+    def test_cache_stores_value(self):
+        cache = StateMemoryCache()
+        cache.store("http://localhost/props/state", "on")
+        assert cache.get("http://localhost/props/state") == "on"
+
+    def test_cache_returns_cached(self):
+        cache = StateMemoryCache()
+        cache.store("http://localhost/props/brightness", 75)
+        # Multiple gets return the same value
+        assert cache.get("http://localhost/props/brightness") == 75
+        assert cache.get("http://localhost/props/brightness") == 75
+
+    def test_cache_updates_on_new_store(self):
+        cache = StateMemoryCache()
+        cache.store("http://localhost/props/state", "off")
+        assert cache.get("http://localhost/props/state") == "off"
+
+        cache.store("http://localhost/props/state", "on")
+        assert cache.get("http://localhost/props/state") == "on"
+
+    def test_cache_returns_default_for_unknown(self):
+        cache = StateMemoryCache()
+        assert cache.get("http://localhost/props/unknown") is None
+        assert cache.get("http://localhost/props/unknown", "default") == "default"
+
+    def test_cache_has(self):
+        cache = StateMemoryCache()
+        assert cache.has("http://localhost/props/state") is False
+        cache.store("http://localhost/props/state", "on")
+        assert cache.has("http://localhost/props/state") is True
+
+    def test_cache_clear(self):
+        cache = StateMemoryCache()
+        cache.store("http://localhost/props/a", 1)
+        cache.store("http://localhost/props/b", 2)
+        assert len(cache.all()) == 2
+
+        cache.clear()
+        assert len(cache.all()) == 0
+
+    def test_cache_all(self):
+        cache = StateMemoryCache()
+        cache.store("http://localhost/props/a", 1)
+        cache.store("http://localhost/props/b", 2)
+        all_vals = cache.all()
+        assert all_vals == {
+            "http://localhost/props/a": 1,
+            "http://localhost/props/b": 2,
+        }
+
+    def test_store_bulk_flat(self):
+        cache = StateMemoryCache()
+        count = cache.store_bulk({
+            "http://localhost/props/state": "on",
+            "http://localhost/props/brightness": 75,
+        })
+        assert count == 2
+        assert cache.get("http://localhost/props/state") == "on"
+        assert cache.get("http://localhost/props/brightness") == 75
+
+    def test_store_bulk_nested(self):
+        cache = StateMemoryCache()
+        count = cache.store_bulk({
+            "light308": {
+                "http://localhost/props/state": "on",
+                "http://localhost/props/brightness": 80,
+            },
+            "blinds308": {
+                "http://localhost/props/position": 50,
+            },
+        })
+        assert count == 3
+        assert cache.get("http://localhost/props/state") == "on"
+        assert cache.get("http://localhost/props/brightness") == 80
+        assert cache.get("http://localhost/props/position") == 50
+
+    def test_store_bulk_empty(self):
+        cache = StateMemoryCache()
+        count = cache.store_bulk({})
+        assert count == 0
+        assert len(cache.all()) == 0


### PR DESCRIPTION
# PR: Integrate BehaviorTree-Based Planning with Cross-Environment Signifier Sharing

## Summary

This PR replaces the JSON-Plan 1.2 planning format with a **BehaviorTree (BT) JSON IR** system throughout the AAMAS 2026 demo agent pipeline. It introduces:

- **BT-based plan generation** via LLM tool calls (`AsyncBTPlanner`)
- **BT compilation and execution** via py_trees tick loop (`IRExecutor`)
- **Cross-environment signifier sharing** via a community HTTP API (`CommunitySignifierClient`)
- **State memory caching** for environment property lookups (`StateMemoryCache`)
- **92 automated tests** (76 unit + 16 integration/E2E)

The result is a complete pipeline: user request -> intent extraction -> BT generation (with signifier hints) -> BT execution -> signifier extraction and community publishing.

---

## Architecture

### New Workflow

```
User -> UserAssistant (classify: QUERY | IMPLICIT | EXPLICIT)
  QUERY -> query_environment_state (with StateMemoryCache)
  IMPLICIT/EXPLICIT -> InteractionSolver:
    1. Query EnvExplorer for signifiers (local)
    2. Query community signifier API (cross-environment)
    3. Build planning context with signifier hints
    4. LLM generates JSON IR behavior tree (AsyncBTPlanner)
    5. Return BT JSON IR to UserAssistant
  -> UserAssistant:
    1. Store plan, summarize, ask confirmation
    2. On approval: compile BT via IRExecutor
    3. Execute py_trees tick loop
    4. Extract signifiers from leaf action nodes
    5. Record locally (EnvExplorer) + publish to community API
```

### Two Environments, Shared Community

```
Lab308 (Yggdrasil :8080)       Community API (:8085)       HomeBench Home 17 (:8090)
  EnvExplorer_308  ---------> [Signifier Store] <---------  EnvExplorer_HB
  InteractionSolver_308                                     InteractionSolver_HB
  UserAssistant_308                                         UserAssistant_HB
```

### Plan Format Change

**Before (JSON-Plan 1.2):**
```json
{"plan_version": "1.2", "steps": [{"action": "turn_on", ...}]}
```

**After (BT JSON IR):**
```json
{
  "plan_type": "behavior_tree",
  "tree": {
    "name": "IncreaseLightSequence",
    "type": "sequence",
    "children": [
      {"name": "TurnOn", "type": "action", "action_url": "http://.../turn_on", "parameters": {}},
      {"name": "SetBrightness", "type": "action", "action_url": "http://.../set_brightness", "parameters": {"brightness": 100}}
    ]
  },
  "explanation": "Turn on the light and set brightness to 100%",
  "intents": ["turn on light308", "set light308 brightness to 100"]
}
```

### BT Node Types

| Type | Role | Key Fields |
|------|------|------------|
| `sequence` | Execute children left-to-right, fail on first failure | `children` |
| `selector` | Try children left-to-right, succeed on first success | `children` |
| `parallel` | Run all children concurrently | `children`, `policy` |
| `action` | HTTP POST to invoke an affordance | `action_url`, `parameters` |
| `condition` | HTTP GET to check a property value | `property_url`, `expected_value`, `operator` |

---

## What Changed

### New Files (16 source + 14 test)

#### `ami_agents/bt_planning/` -- BT Infrastructure (ported + new)

| File | Description |
|------|-------------|
| `nodes/affordance_nodes.py` | py_trees nodes: `ActionAffordanceNode` (HTTP POST), `PropertyConditionNode` (HTTP GET + equality check), `ComparisonPropertyConditionNode` (operators: ==, !=, >, <, >=, <=, in) |
| `nodes/http_client.py` | Sync HTTP client (httpx) with `HTTPResponse` dataclass, retry, timeouts |
| `nodes/blackboard_keys.py` | Standardized py_trees blackboard key constants |
| `planning/bt_planner.py` | `AsyncBTPlanner` -- generates BT JSON IR via OpenAI tool calls with validation retry loop. Includes `_normalize_tree()` to auto-fill missing `name` fields from smaller LLMs |
| `planning/schema.py` | `TREE_PARAMETER_SCHEMA` and `GENERATE_BT_TOOL` for OpenAI function calling |
| `planning/prompts.py` | `BT_PLANNING_SYSTEM_PROMPT`, `format_capability_context()`, `format_signifier_hints()` -- handles both BT-repo and EnvExplorer field names |
| `execution/ir_executor.py` | `IRExecutor` -- compiles JSON IR to py_trees, runs tick loop, returns `ExecutionResult` |
| `execution/base.py` | `ExecutionResult` dataclass (success, ticks, final_status, tick_history, error) |
| `signifier_bridge.py` | `extract_signifiers_from_bt()` -- walk BT, collect action nodes as signifiers; `build_bt_from_signifiers()` -- fast-path BT construction from matched signifiers (skips LLM) |

#### `ami_agents/shared/` -- Shared Services

| File | Description |
|------|-------------|
| `community/community_client.py` | `CommunitySignifierClient` -- async HTTP client for community signifier API (`POST /matching/match`, `POST /signifiers`) with timeout and error handling |
| `state_memory.py` | `StateMemoryCache` -- dict-based property cache (`store`, `get`, `has`, `clear`, `store_bulk`) with flat and nested state ingestion |

### Modified Files (8)

#### `ami_agents/agents/interaction_solver/interaction_solver_agent.py`

- Replaced `_generate_plan()` -- now calls `AsyncBTPlanner.generate_bt()` instead of building JSON-Plan 1.2 prompts
- Replaced `_try_build_plan_from_signifiers()` -- uses `build_bt_from_signifiers()` from signifier bridge for fast-path BT construction
- Removed `_build_planning_prompt()` entirely (handled by `bt_planner.py` + `prompts.py`)
- Added `self.bt_planner = AsyncBTPlanner(max_attempts=3)` initialization
- Added `CommunitySignifierClient` initialization from config/env vars
- Modified `_gather_signifier_matches()` to query **both** local EnvExplorer AND community API, with local-first merge
- Updated all response formats from `plan_version: "1.2"` to `plan_type: "behavior_tree"`

#### `ami_agents/agents/user_assistant/tools.py`

- Replaced `ExecutePlanTool` with `ExecuteBTTool`:
  - Parses BT JSON IR `tree` field
  - Uses `IRExecutor(max_ticks=50)` for compilation + execution
  - Wraps sync py_trees tick loop in `asyncio.run_in_executor()` for SPADE async context
  - Extracts signifiers via `extract_signifiers_from_bt()` after execution
  - Publishes signifiers to community via `CommunitySignifierClient`
  - Preserves hash-based approval gating
- Updated `StoreLatestPlanTool` for BT format (node counting, BT preview)
- Updated `QueryEnvironmentStateTool` with state memory cache integration (check cache first, store results after query)
- Added state cache invalidation in `ExecuteBTTool` after plan execution
- Added helper functions: `_count_bt_nodes()`, `_bt_preview()`

#### `ami_agents/agents/user_assistant/user_assistant_agent.py`

- Added `StateMemoryCache` initialization (`self.state_memory`)
- Added `CommunitySignifierClient` initialization (`self.community_client`) from config/env vars
- Updated imports for `ExecuteBTTool`

#### `ami_agents/agents/user_assistant/prompts.py`

- Updated system prompt references from "JSON-Plan 1.2" to "behavior tree plan"
- Updated tool descriptions for BT workflow (plan_type="behavior_tree", non-null "tree" field)

#### `ami_agents/shared/models/plan.py`

- `BehaviorTreePlan` now supports both legacy `NodeTemplate` and BT JSON IR `tree_spec`
- Added `from_json_ir()` class method for creating from JSON IR plan dicts
- Implemented `get_all_signifiers()` -- recursive extraction of action nodes
- Implemented `get_node_by_id()` and `update_node_status()` for NodeTemplate trees

#### `ami_agents/config/agents.yaml`

- Added `planning.community` section (enabled, api_url, timeout)
- Changed `from_community: false` to `true`
- Added `max_planning_attempts: 3` for BT generation retries
- Added multi-environment demo config (`environments.lab308`, `environments.homebench`)
- Added shared `community.api_url` section

#### `requirements.txt`

- Added `py-trees>=2.4.0`

#### `pytest.ini`

- Added `e2e` marker registration

---

## Test Suite

### Unit Tests (76 tests, no external dependencies)

| Test File | Tests | What It Covers |
|-----------|-------|---------------|
| `test_affordance_nodes.py` | 14 | ActionAffordanceNode (success/failure/HTTP error/params), PropertyConditionNode (match/mismatch/error/value_path), ComparisonPropertyConditionNode (>, <, !=, in, >=) |
| `test_ir_executor.py` | 15 | Compilation (sequence/selector/parallel/action/condition/nested/unknown type/missing URL), Execution (empty/none/success/failure/invalid spec/result serialization) |
| `test_bt_schema.py` | 15 | Schema validation (valid sequence/selector/parallel/action/condition/nested, invalid empty/missing type/unknown type/missing URL/missing property/missing expected/empty children/no children/invalid child/not dict) |
| `test_signifier_bridge.py` | 14 | Extraction (single/multiple/nested actions, skips conditions, maps intent, with params, empty tree, workspace_id), Building (single/multi intent, no matches, partial match, empty intents, no affordance_uri) |
| `test_community_client.py` | 7 | Match (success/empty/server error/connection error), Publish (success/failure/connection error) |
| `test_state_memory.py` | 10 | Store/get/update/default/has/clear/all + store_bulk (flat/nested/empty) |

### Integration Tests (8 tests, require `OPENAI_API_KEY`)

| Test File | Tests | What It Covers |
|-----------|-------|---------------|
| `test_bt_planner_llm.py` | 8 | BT Generation: single action, multiple actions, impossible request, validation, URL provenance. Signifier Hints: hint influence, independent planning, cross-env hints (Lab308 hints -> HomeBench affordances) |

### E2E Tests (8 tests, require `OPENAI_API_KEY`)

| Test File | Tests | What It Covers |
|-----------|-------|---------------|
| `test_demo_lab308.py` | 3 | "Too dark" scenario: BT generation with 3 intents, signifier extraction, IRExecutor dry-run validation |
| `test_demo_homebench.py` | 3 | "Can't read" scenario: BT generation for Home 17, cross-env signifier hints from Lab308, signifier extraction with HomeBench URLs |
| `test_cross_env_sharing.py` | 2 | Full flow: Lab308 BT -> extract signifiers -> inject as hints -> HomeBench BT generation; intent-level transfer (Lab308 has setBrightness, Home 17 has turnOn/setColor) |

### Test Output

```
# Unit tests (no API key needed)
$ pytest tests/unit/ -v
76 passed in 0.40s

# Integration + E2E (with API key)
$ OPENAI_API_KEY=... pytest tests/integration/ tests/e2e/ -v
16 passed in 52.27s

# Full suite
$ OPENAI_API_KEY=... pytest tests/ -v
92 passed
```

---

## Key Design Decisions

### 1. Tree Normalization for Smaller LLMs

`gpt-4o-mini` consistently omits the `name` field in generated BT JSON IR. Rather than forcing retries (which waste tokens), `AsyncBTPlanner._normalize_tree()` auto-fills sensible defaults:
- Action nodes: name derived from `action_url` (e.g., `turn_on` -> `TurnOn`)
- Condition nodes: name from `property_url` + `expected_value`
- Composite nodes: numbered names (e.g., `Sequence_1`)

`IRExecutor` validation was also relaxed to not require `name`, since the compiler defaults to `"unnamed"`.

### 2. Sync/Async Bridge

py_trees tick loop is synchronous, but SPADE agents are async. `ExecuteBTTool` wraps execution in `asyncio.run_in_executor()`:
```python
exec_result = await loop.run_in_executor(None, self._executor.execute_from_spec, tree_spec)
```

### 3. Signifier Merge Strategy

`InteractionSolver._gather_signifier_matches()` queries both local EnvExplorer (SPADE RPC) and community API (HTTP), then merges:
- Local matches take priority (same environment, more relevant)
- Community matches supplement gaps (cross-environment transfer)
- Deduplication by `signifier_id`

### 4. Fast-Path Signifier Reuse

When ALL intents have signifier matches, `build_bt_from_signifiers()` constructs a BT JSON IR directly without calling the LLM, saving latency and cost. The resulting plan is tagged `signifier_reuse: True` so `ExecuteBTTool` skips re-recording signifiers.

### 5. State Cache Invalidation

`StateMemoryCache` caches `property_uri -> value` from `query_environment_state` responses. After BT execution (which changes environment state), the entire cache is cleared to avoid stale reads.

---

## Demo Scenarios

### Scenario 1: Lab308 -- "It's too dark in here"

1. UserAssistant classifies as IMPLICIT
2. Derives intents: `turn on light308`, `set light308 brightness to 100`, `set blinds308 position to 100`
3. InteractionSolver generates BT (sequence of 3 actions)
4. User confirms -> IRExecutor compiles and ticks -> actions invoke HTTP endpoints
5. Signifiers extracted and published to community

### Scenario 2: HomeBench Home 17 -- "I can't read anything at my desk"

1. InteractionSolver queries community -> finds Lab308 signifiers for "increase light"
2. Planning context includes signifier hints: "past experience: use light.turnOn when dark"
3. LLM generates BT using Home 17 affordances (`studyRoomLight/turn_on`, `studyRoomLight/set_color`)
4. Lab308 had `setBrightness`, Home 17 has `turnOn`/`setColor` -- demonstrates **intent-level transfer**, not exact affordance copying

