### PR TITLE
Node-type registry for JSON-serialisable custom BT nodes (#22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,6 @@ conda run -n ami python tests/manual_test_full_flow_plan.py --sequence 3 --clear
 | Tweak BT planner prompts | `ami_agents/bt_planning/planning/prompts.py` |
 | Change a timeout | `ami_agents/config/agents.yaml > timeouts:` |
 | Add a config-driven feature | yaml key + `LLMClientConfig`-style dataclass in `utils/` |
-| Add a new BT node type | `ami_agents/bt_planning/nodes/` + register in `signifier_bridge.py` if needed |
+| Add a new BT node type | Define the `py_trees` node in `ami_agents/bt_planning/nodes/`, then `register_node_type(...)` in `nodes/registry.py` (compile + validate). Custom compute logic goes through a named op in `compute_node.py` — never embed code in the IR (keeps it JSON-serialisable for cross-agent transport, issue #22) |
 | Wire a new HA entity into the demo | `ami_agents/environment/integration/HomeAssistant/` + `config/environment.yaml` |
 | Run a single sequence end-to-end | `tests/manual_test_full_flow_plan.py --sequence <N>` |

--- a/ami_agents/bt_planning/execution/ir_executor.py
+++ b/ami_agents/bt_planning/execution/ir_executor.py
@@ -6,33 +6,14 @@ for the AAMAS 2026 demo multi-agent system.
 """
 
 import logging
-from typing import Optional
 
 import py_trees
 from py_trees.common import Status
 
-from ..nodes.affordance_nodes import (
-    ActionAffordanceNode,
-    PropertyConditionNode,
-    ComparisonPropertyConditionNode,
-    ComparisonOperator,
-)
+from ..nodes.registry import compile_node, validate_node
 from .base import ExecutionResult
 
 logger = logging.getLogger(__name__)
-
-
-OPERATOR_MAP = {
-    "==": ComparisonOperator.EQUAL,
-    "!=": ComparisonOperator.NOT_EQUAL,
-    ">": ComparisonOperator.GREATER_THAN,
-    ">=": ComparisonOperator.GREATER_THAN_OR_EQUAL,
-    "<": ComparisonOperator.LESS_THAN,
-    "<=": ComparisonOperator.LESS_THAN_OR_EQUAL,
-    "in": ComparisonOperator.IN,
-    "not_in": ComparisonOperator.NOT_IN,
-    "contains": ComparisonOperator.CONTAINS,
-}
 
 
 class IRExecutor:
@@ -93,59 +74,17 @@ class IRExecutor:
         """
         Compile a JSON specification to py_trees.
 
+        Dispatches each node through the node registry (``nodes/registry.py``),
+        so custom node types (e.g. ``compute``) compile the same way the five
+        built-ins do.
+
         Args:
             spec: JSON tree specification
 
         Returns:
             py_trees behavior
         """
-        node_type = spec.get("type")
-        name = spec.get("name", "unnamed")
-
-        if node_type == "sequence":
-            children = [self._compile(child) for child in spec.get("children", [])]
-            return py_trees.composites.Sequence(name=name, memory=True, children=children)
-
-        elif node_type == "selector":
-            children = [self._compile(child) for child in spec.get("children", [])]
-            return py_trees.composites.Selector(name=name, memory=False, children=children)
-
-        elif node_type == "parallel":
-            children = [self._compile(child) for child in spec.get("children", [])]
-            policy_name = spec.get("policy", "success_on_all")
-            if policy_name == "success_on_one":
-                policy = py_trees.common.ParallelPolicy.SuccessOnOne()
-            else:
-                policy = py_trees.common.ParallelPolicy.SuccessOnAll()
-            return py_trees.composites.Parallel(name=name, policy=policy, children=children)
-
-        elif node_type == "action":
-            return ActionAffordanceNode(
-                name=name,
-                action_url=spec["action_url"],
-                parameters=spec.get("parameters", {}),
-            )
-
-        elif node_type == "condition":
-            operator = spec.get("operator")
-            if operator and operator != "==":
-                return ComparisonPropertyConditionNode(
-                    name=name,
-                    property_url=spec["property_url"],
-                    expected_value=spec["expected_value"],
-                    operator=OPERATOR_MAP.get(operator, ComparisonOperator.EQUAL),
-                    value_path=spec.get("value_path"),
-                )
-            else:
-                return PropertyConditionNode(
-                    name=name,
-                    property_url=spec["property_url"],
-                    expected_value=spec["expected_value"],
-                    value_path=spec.get("value_path"),
-                )
-
-        else:
-            raise ValueError(f"Unknown node type: {node_type}")
+        return compile_node(spec, self._compile)
 
     def _execute_tree(self, tree: py_trees.behaviour.Behaviour) -> ExecutionResult:
         """
@@ -202,46 +141,11 @@ class IRExecutor:
         return self._validate_tree(spec)
 
     def _validate_tree(self, spec: dict, path: str = "tree") -> list[str]:
-        """Validate that the tree spec is non-empty and structurally sound."""
-        errors: list[str] = []
+        """
+        Validate that the tree spec is non-empty and structurally sound.
 
-        if not spec:
-            errors.append(f"{path}: tree is empty")
-            return errors
-
-        if not isinstance(spec, dict):
-            errors.append(f"{path}: expected object, got {type(spec).__name__}")
-            return errors
-
-        # 'name' is optional -- the compiler defaults to "unnamed" and the
-        # AsyncBTPlanner normalizer fills in sensible defaults.  We only warn
-        # (do NOT add to errors) so that trees without names still pass.
-        node_type = spec.get("type")
-        valid_types = {"sequence", "selector", "parallel", "action", "condition"}
-        if node_type not in valid_types:
-            errors.append(f"{path}: missing or invalid 'type'")
-
-        # Composite nodes
-        if node_type in {"sequence", "selector", "parallel"}:
-            children = spec.get("children")
-            if not isinstance(children, list) or not children:
-                errors.append(f"{path}: composite nodes require non-empty 'children'")
-            else:
-                for idx, child in enumerate(children):
-                    errors.extend(
-                        self._validate_tree(child, path=f"{path}.children[{idx}]")
-                    )
-        # Action nodes
-        elif node_type == "action":
-            action_url = spec.get("action_url")
-            if not action_url or not isinstance(action_url, str):
-                errors.append(f"{path}: action nodes require 'action_url'")
-        # Condition nodes
-        elif node_type == "condition":
-            property_url = spec.get("property_url")
-            if not property_url or not isinstance(property_url, str):
-                errors.append(f"{path}: condition nodes require 'property_url'")
-            if "expected_value" not in spec:
-                errors.append(f"{path}: condition nodes require 'expected_value'")
-
-        return errors
+        Delegates per-node validation to the node registry so built-in and
+        custom node types share one source of truth. ``name`` stays optional —
+        the compiler defaults it to "unnamed".
+        """
+        return validate_node(spec, path)

--- a/ami_agents/bt_planning/nodes/__init__.py
+++ b/ami_agents/bt_planning/nodes/__init__.py
@@ -13,6 +13,19 @@ from .affordance_nodes import (
 )
 from .http_client import HTTPClient, HTTPClientConfig, HTTPError, HTTPResponse
 from .blackboard_keys import BlackboardKeys
+from .compute_node import (
+    BlackboardComputeNode,
+    COMPUTE_OPS,
+    register_compute_op,
+    registered_compute_ops,
+)
+from .registry import (
+    NODE_REGISTRY,
+    compile_node,
+    register_node_type,
+    registered_types,
+    validate_node,
+)
 
 __all__ = [
     "ActionAffordanceNode",
@@ -27,4 +40,13 @@ __all__ = [
     "HTTPError",
     "HTTPResponse",
     "BlackboardKeys",
+    "BlackboardComputeNode",
+    "COMPUTE_OPS",
+    "register_compute_op",
+    "registered_compute_ops",
+    "NODE_REGISTRY",
+    "compile_node",
+    "register_node_type",
+    "registered_types",
+    "validate_node",
 ]

--- a/ami_agents/bt_planning/nodes/compute_node.py
+++ b/ami_agents/bt_planning/nodes/compute_node.py
@@ -1,0 +1,120 @@
+"""
+Blackboard compute node — the canonical "custom compute node" template.
+
+This is the node class issue #22 is about: a node that runs custom logic
+reading from and writing to the py-trees blackboard. The key design choice
+that keeps it JSON-serialisable (and avoids ``pickle`` across agents) is that
+the custom logic is **referenced by name**, not embedded as code.
+
+A compute node's JSON IR is pure data::
+
+    {
+        "name": "AggregatePresence",
+        "type": "compute",
+        "op": "any",                       # registered op name, NOT a lambda
+        "inputs": ["sensor/hall", "sensor/kitchen"],   # blackboard keys to read
+        "output": "presence/anywhere",     # blackboard key to write
+        "args": {}                          # optional op arguments
+    }
+
+The actual Python implementation of ``op`` lives in :data:`COMPUTE_OPS`, which
+is shared code present in both the InteractionSolver and the UserAssistant
+(they both import ``ami_agents``). Only the *name* crosses the wire, so a new
+environment can reconstruct the node as long as it has the same shared package
+— exactly like the built-in action/condition nodes are reconstructed by
+``IRExecutor`` today.
+"""
+
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+import py_trees
+from py_trees.common import Status
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Compute-op registry: named, pure, JSON-config-driven functions.
+# Each op takes (values, args) where `values` are the blackboard reads (in the
+# order of `inputs`) and `args` is the node's optional `args` dict.
+# ---------------------------------------------------------------------------
+ComputeOp = Callable[[List[Any], Dict[str, Any]], Any]
+
+COMPUTE_OPS: Dict[str, ComputeOp] = {}
+
+
+def register_compute_op(name: str, fn: ComputeOp) -> None:
+    """Register a named compute op usable from a ``compute`` node's ``op`` field."""
+    COMPUTE_OPS[name] = fn
+
+
+def registered_compute_ops() -> List[str]:
+    return sorted(COMPUTE_OPS)
+
+
+# Built-in ops. Kept deliberately small and side-effect free.
+register_compute_op("all", lambda values, args: all(values))
+register_compute_op("any", lambda values, args: any(values))
+register_compute_op("not", lambda values, args: not (values[0] if values else None))
+register_compute_op("sum", lambda values, args: sum(v for v in values if isinstance(v, (int, float))))
+register_compute_op("max", lambda values, args: max((v for v in values if v is not None), default=None))
+register_compute_op("min", lambda values, args: min((v for v in values if v is not None), default=None))
+
+
+class BlackboardComputeNode(py_trees.behaviour.Behaviour):
+    """
+    A custom node that reads inputs from the blackboard, applies a registered
+    op, and writes the result back to the blackboard.
+
+    Returns ``SUCCESS`` whenever the op runs without raising; the computed
+    value is left on the blackboard for downstream nodes to consume. Returns
+    ``FAILURE`` only on an unknown op or a raised exception. (A future variant
+    could gate on the truthiness of the result; kept simple here.)
+    """
+
+    def __init__(
+        self,
+        name: str,
+        op: str,
+        inputs: Optional[List[str]] = None,
+        output: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(name)
+        self.op = op
+        self.inputs = list(inputs or [])
+        self.output = output
+        self.args = dict(args or {})
+
+        self.blackboard = self.attach_blackboard_client(name=self.name)
+        for key in self.inputs:
+            self.blackboard.register_key(key=key, access=py_trees.common.Access.READ)
+        if self.output:
+            self.blackboard.register_key(key=self.output, access=py_trees.common.Access.WRITE)
+
+    def update(self) -> Status:
+        fn = COMPUTE_OPS.get(self.op)
+        if fn is None:
+            self.feedback_message = f"unknown compute op: {self.op!r}"
+            logger.warning("[%s] %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        values: List[Any] = []
+        for key in self.inputs:
+            try:
+                values.append(self.blackboard.get(key))
+            except KeyError:
+                values.append(None)
+
+        try:
+            result = fn(values, self.args)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.feedback_message = f"compute op {self.op!r} raised: {exc}"
+            logger.warning("[%s] %s", self.name, self.feedback_message)
+            return Status.FAILURE
+
+        if self.output:
+            self.blackboard.set(self.output, result)
+        self.feedback_message = f"{self.op}({self.inputs}) -> {result!r}"
+        return Status.SUCCESS

--- a/ami_agents/bt_planning/nodes/registry.py
+++ b/ami_agents/bt_planning/nodes/registry.py
@@ -1,0 +1,212 @@
+"""
+Node-type registry — the extensible compile/validate dispatch for BT JSON IR.
+
+This decouples ``IRExecutor`` from a hard-coded ``if node_type == ...`` ladder.
+Every node type (the five built-ins plus any custom compute node) registers:
+
+- a ``compile`` factory: ``(spec, compile_child) -> py_trees.behaviour.Behaviour``
+- a ``validate`` function: ``(spec, path, validate_child) -> list[str]``
+
+Because a node is identified in the IR purely by its ``"type"`` string and a
+JSON-serialisable config, custom nodes round-trip as plain JSON. Reconstruction
+("load") is done here by name; persistence ("save") is just ``json.dumps`` of
+the IR. This is what lets custom compute nodes cross the ISA -> UA wire without
+``pickle`` — see issue #22 and ``compute_node.py``.
+
+To add a new node type, call :func:`register_node_type` (typically at import
+time of the module that defines the node class).
+"""
+
+from typing import Any, Callable, Dict, List, Optional
+
+import py_trees
+
+from .affordance_nodes import (
+    ActionAffordanceNode,
+    ComparisonOperator,
+    ComparisonPropertyConditionNode,
+    PropertyConditionNode,
+)
+from .compute_node import BlackboardComputeNode, COMPUTE_OPS
+
+# A compiler turns a single (child) spec dict into a runnable py_trees node.
+ChildCompiler = Callable[[dict], py_trees.behaviour.Behaviour]
+# A child validator returns errors for a (child) spec at a given path.
+ChildValidator = Callable[[dict, str], List[str]]
+
+CompileFn = Callable[[dict, ChildCompiler], py_trees.behaviour.Behaviour]
+ValidateFn = Callable[[dict, str, ChildValidator], List[str]]
+
+
+OPERATOR_MAP = {
+    "==": ComparisonOperator.EQUAL,
+    "!=": ComparisonOperator.NOT_EQUAL,
+    ">": ComparisonOperator.GREATER_THAN,
+    ">=": ComparisonOperator.GREATER_THAN_OR_EQUAL,
+    "<": ComparisonOperator.LESS_THAN,
+    "<=": ComparisonOperator.LESS_THAN_OR_EQUAL,
+    "in": ComparisonOperator.IN,
+    "not_in": ComparisonOperator.NOT_IN,
+    "contains": ComparisonOperator.CONTAINS,
+}
+
+
+class NodeType:
+    """A registered node type: how to compile it and how to validate it."""
+
+    __slots__ = ("name", "compile", "validate")
+
+    def __init__(self, name: str, compile: CompileFn, validate: ValidateFn):
+        self.name = name
+        self.compile = compile
+        self.validate = validate
+
+
+NODE_REGISTRY: Dict[str, NodeType] = {}
+
+
+def register_node_type(name: str, *, compile: CompileFn, validate: ValidateFn) -> None:
+    """Register (or override) a node type by its IR ``"type"`` name."""
+    NODE_REGISTRY[name] = NodeType(name, compile, validate)
+
+
+def registered_types() -> List[str]:
+    return sorted(NODE_REGISTRY)
+
+
+def compile_node(spec: dict, compile_child: ChildCompiler) -> py_trees.behaviour.Behaviour:
+    """Compile one IR node to a py_trees behaviour, dispatching via the registry."""
+    node_type = spec.get("type")
+    entry = NODE_REGISTRY.get(node_type)
+    if entry is None:
+        raise ValueError(
+            f"Unknown node type: {node_type!r}. Registered: {registered_types()}"
+        )
+    return entry.compile(spec, compile_child)
+
+
+def validate_node(spec: Any, path: str = "tree") -> List[str]:
+    """Validate one IR node (recursively) via the registry. Returns error strings."""
+    if not spec:
+        return [f"{path}: tree is empty"]
+    if not isinstance(spec, dict):
+        return [f"{path}: expected object, got {type(spec).__name__}"]
+
+    entry = NODE_REGISTRY.get(spec.get("type"))
+    if entry is None:
+        return [f"{path}: missing or invalid 'type'"]
+
+    return entry.validate(spec, path, validate_node)
+
+
+# ---------------------------------------------------------------------------
+# Built-in node types
+# ---------------------------------------------------------------------------
+def _name(spec: dict) -> str:
+    return spec.get("name", "unnamed")
+
+
+def _compile_sequence(spec, compile_child):
+    children = [compile_child(c) for c in spec.get("children", [])]
+    return py_trees.composites.Sequence(name=_name(spec), memory=True, children=children)
+
+
+def _compile_selector(spec, compile_child):
+    children = [compile_child(c) for c in spec.get("children", [])]
+    return py_trees.composites.Selector(name=_name(spec), memory=False, children=children)
+
+
+def _compile_parallel(spec, compile_child):
+    children = [compile_child(c) for c in spec.get("children", [])]
+    if spec.get("policy") == "success_on_one":
+        policy = py_trees.common.ParallelPolicy.SuccessOnOne()
+    else:
+        policy = py_trees.common.ParallelPolicy.SuccessOnAll()
+    return py_trees.composites.Parallel(name=_name(spec), policy=policy, children=children)
+
+
+def _compile_action(spec, compile_child):
+    return ActionAffordanceNode(
+        name=_name(spec),
+        action_url=spec["action_url"],
+        parameters=spec.get("parameters", {}),
+    )
+
+
+def _compile_condition(spec, compile_child):
+    operator = spec.get("operator")
+    if operator and operator != "==":
+        return ComparisonPropertyConditionNode(
+            name=_name(spec),
+            property_url=spec["property_url"],
+            expected_value=spec["expected_value"],
+            operator=OPERATOR_MAP.get(operator, ComparisonOperator.EQUAL),
+            value_path=spec.get("value_path"),
+        )
+    return PropertyConditionNode(
+        name=_name(spec),
+        property_url=spec["property_url"],
+        expected_value=spec["expected_value"],
+        value_path=spec.get("value_path"),
+    )
+
+
+def _compile_compute(spec, compile_child):
+    return BlackboardComputeNode(
+        name=_name(spec),
+        op=spec["op"],
+        inputs=spec.get("inputs", []),
+        output=spec.get("output"),
+        args=spec.get("args", {}),
+    )
+
+
+def _validate_composite(spec, path, validate_child):
+    errors: List[str] = []
+    children = spec.get("children")
+    if not isinstance(children, list) or not children:
+        errors.append(f"{path}: composite nodes require non-empty 'children'")
+    else:
+        for idx, child in enumerate(children):
+            errors.extend(validate_child(child, f"{path}.children[{idx}]"))
+    return errors
+
+
+def _validate_action(spec, path, validate_child):
+    url = spec.get("action_url")
+    if not url or not isinstance(url, str):
+        return [f"{path}: action nodes require 'action_url'"]
+    return []
+
+
+def _validate_condition(spec, path, validate_child):
+    errors: List[str] = []
+    url = spec.get("property_url")
+    if not url or not isinstance(url, str):
+        errors.append(f"{path}: condition nodes require 'property_url'")
+    if "expected_value" not in spec:
+        errors.append(f"{path}: condition nodes require 'expected_value'")
+    return errors
+
+
+def _validate_compute(spec, path, validate_child):
+    errors: List[str] = []
+    op = spec.get("op")
+    if not op or not isinstance(op, str):
+        errors.append(f"{path}: compute nodes require 'op'")
+    elif op not in COMPUTE_OPS:
+        errors.append(f"{path}: unknown compute op '{op}' (registered: {sorted(COMPUTE_OPS)})")
+    if not spec.get("output") or not isinstance(spec.get("output"), str):
+        errors.append(f"{path}: compute nodes require an 'output' blackboard key")
+    inputs = spec.get("inputs", [])
+    if not isinstance(inputs, list):
+        errors.append(f"{path}: compute 'inputs' must be a list of blackboard keys")
+    return errors
+
+
+register_node_type("sequence", compile=_compile_sequence, validate=_validate_composite)
+register_node_type("selector", compile=_compile_selector, validate=_validate_composite)
+register_node_type("parallel", compile=_compile_parallel, validate=_validate_composite)
+register_node_type("action", compile=_compile_action, validate=_validate_action)
+register_node_type("condition", compile=_compile_condition, validate=_validate_condition)
+register_node_type("compute", compile=_compile_compute, validate=_validate_compute)

--- a/ami_agents/bt_planning/serialization.py
+++ b/ami_agents/bt_planning/serialization.py
@@ -1,0 +1,52 @@
+"""
+Persist/load a BehaviorTree JSON IR for cross-agent transport (issue #22).
+
+The BT IR is pure JSON — including custom ``compute`` nodes, whose logic is
+referenced by registered name rather than embedded as code (see
+``nodes/compute_node.py``). That means a tree can be sent between the
+InteractionSolver and the UserAssistant as a UTF-8 JSON string (the existing
+SPADE message-body format) and reconstructed on the far side, with **no
+``pickle`` and no arbitrary-code-execution risk**.
+
+This module gives that contract an explicit, testable home:
+
+- :func:`serialize_tree`   IR dict   -> JSON ``str``
+- :func:`to_bytes`         IR dict   -> UTF-8 ``bytes`` (for byte-message transport)
+- :func:`deserialize_tree` ``str``/``bytes`` -> IR dict
+- :func:`validate_tree`    IR dict   -> list of error strings (registry-driven)
+
+The round-trip ``deserialize_tree(serialize_tree(spec)) == spec`` holds for any
+tree built from registered node types.
+"""
+
+import json
+from typing import Any, List, Union
+
+from .nodes.registry import validate_node
+
+
+def serialize_tree(spec: dict, *, indent: Union[int, None] = None) -> str:
+    """Serialise a BT IR dict to a JSON string."""
+    if not isinstance(spec, dict):
+        raise TypeError(f"BT IR must be a dict, got {type(spec).__name__}")
+    return json.dumps(spec, indent=indent, ensure_ascii=False)
+
+
+def to_bytes(spec: dict) -> bytes:
+    """Serialise a BT IR dict to UTF-8 bytes for byte-message transport."""
+    return serialize_tree(spec).encode("utf-8")
+
+
+def deserialize_tree(payload: Union[str, bytes, bytearray]) -> dict:
+    """Load a BT IR dict from a JSON string or UTF-8 bytes."""
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode("utf-8")
+    spec = json.loads(payload)
+    if not isinstance(spec, dict):
+        raise ValueError("Behavior tree payload must decode to a JSON object")
+    return spec
+
+
+def validate_tree(spec: Any) -> List[str]:
+    """Validate a BT IR dict against the node registry. Empty list == valid."""
+    return validate_node(spec, "tree")

--- a/tests/unit/test_node_registry.py
+++ b/tests/unit/test_node_registry.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for the BT node registry + JSON serialization (issue #22).
+
+Covers:
+- the registry knows the built-ins plus the custom ``compute`` type
+- custom compute nodes validate, round-trip as JSON, and compile/execute
+- unknown node types fail validation and compilation
+- third parties can register their own node types
+"""
+
+import py_trees
+import pytest
+from py_trees.common import Status
+
+from ami_agents.bt_planning.execution.ir_executor import IRExecutor
+from ami_agents.bt_planning.nodes import registry
+from ami_agents.bt_planning.nodes.compute_node import BlackboardComputeNode
+from ami_agents.bt_planning.serialization import (
+    deserialize_tree,
+    serialize_tree,
+    to_bytes,
+    validate_tree,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Registry contents
+# --------------------------------------------------------------------------- #
+def test_registry_contains_builtins_and_compute():
+    types = set(registry.registered_types())
+    assert {"sequence", "selector", "parallel", "action", "condition"} <= types
+    assert "compute" in types
+
+
+# --------------------------------------------------------------------------- #
+# Custom compute node — validation
+# --------------------------------------------------------------------------- #
+def _compute_spec(**overrides):
+    spec = {
+        "name": "AggregatePresence",
+        "type": "compute",
+        "op": "any",
+        "inputs": ["sensor/hall", "sensor/kitchen"],
+        "output": "presence/anywhere",
+    }
+    spec.update(overrides)
+    return spec
+
+
+def test_compute_node_validates_ok():
+    assert validate_tree(_compute_spec()) == []
+
+
+def test_compute_node_missing_op():
+    spec = _compute_spec()
+    del spec["op"]
+    errors = validate_tree(spec)
+    assert any("op" in e for e in errors)
+
+
+def test_compute_node_unknown_op():
+    errors = validate_tree(_compute_spec(op="definitely_not_an_op"))
+    assert any("unknown compute op" in e for e in errors)
+
+
+def test_compute_node_missing_output():
+    spec = _compute_spec()
+    del spec["output"]
+    errors = validate_tree(spec)
+    assert any("output" in e for e in errors)
+
+
+# --------------------------------------------------------------------------- #
+# Unknown node types
+# --------------------------------------------------------------------------- #
+def test_unknown_type_fails_validation():
+    errors = validate_tree({"name": "X", "type": "banana"})
+    assert any("type" in e for e in errors)
+
+
+def test_unknown_type_fails_compile():
+    executor = IRExecutor(max_ticks=3)
+    with pytest.raises(ValueError, match="Unknown node type"):
+        executor._compile({"name": "X", "type": "banana"})
+
+
+# --------------------------------------------------------------------------- #
+# Serialization round-trip (the #22 contract)
+# --------------------------------------------------------------------------- #
+def test_json_roundtrip_with_compute_node():
+    tree = {
+        "name": "Root",
+        "type": "sequence",
+        "children": [
+            _compute_spec(),
+            {
+                "name": "TurnOn",
+                "type": "action",
+                "action_url": "http://localhost:8080/light/turn_on",
+            },
+        ],
+    }
+    assert deserialize_tree(serialize_tree(tree)) == tree
+
+
+def test_bytes_roundtrip():
+    tree = _compute_spec()
+    payload = to_bytes(tree)
+    assert isinstance(payload, bytes)
+    assert deserialize_tree(payload) == tree
+
+
+def test_deserialize_rejects_non_object():
+    with pytest.raises(ValueError):
+        deserialize_tree("[1, 2, 3]")
+
+
+# --------------------------------------------------------------------------- #
+# Compute node execution: reads inputs, writes output to the blackboard
+# --------------------------------------------------------------------------- #
+def test_compute_node_reads_and_writes_blackboard():
+    node = BlackboardComputeNode(
+        name="SumTwo",
+        op="sum",
+        inputs=["t/registry/a", "t/registry/b"],
+        output="t/registry/out",
+    )
+
+    writer = py_trees.blackboard.Client(name="writer")
+    writer.register_key(key="t/registry/a", access=py_trees.common.Access.WRITE)
+    writer.register_key(key="t/registry/b", access=py_trees.common.Access.WRITE)
+    writer.set("t/registry/a", 2)
+    writer.set("t/registry/b", 3)
+
+    node.setup()
+    node.initialise()
+    assert node.update() == Status.SUCCESS
+
+    reader = py_trees.blackboard.Client(name="reader")
+    reader.register_key(key="t/registry/out", access=py_trees.common.Access.READ)
+    assert reader.get("t/registry/out") == 5
+
+
+def test_executor_runs_tree_with_compute_node():
+    tree = {
+        "name": "ComputeOnly",
+        "type": "sequence",
+        "children": [_compute_spec(op="any", output="t/registry/exec_out")],
+    }
+    result = IRExecutor(max_ticks=3).execute_from_spec(tree)
+    assert result.success is True
+
+
+# --------------------------------------------------------------------------- #
+# Third-party node-type registration
+# --------------------------------------------------------------------------- #
+def test_register_custom_node_type():
+    def _compile_always_succeed(spec, compile_child):
+        return py_trees.behaviours.Success(name=spec.get("name", "ok"))
+
+    def _validate_always_succeed(spec, path, validate_child):
+        return []
+
+    registry.register_node_type(
+        "always_succeed",
+        compile=_compile_always_succeed,
+        validate=_validate_always_succeed,
+    )
+    try:
+        spec = {"name": "Y", "type": "always_succeed"}
+        assert validate_tree(spec) == []
+        result = IRExecutor(max_ticks=2).execute_from_spec(spec)
+        assert result.success is True
+    finally:
+        registry.NODE_REGISTRY.pop("always_succeed", None)


### PR DESCRIPTION
## Summary

Implements issue #22: a way to persist/load BehaviorTrees containing **custom compute nodes** (which read/write the blackboard) across the InteractionSolver → UserAssistant message boundary.

The issue suggested `pickle`. This takes a different route that keeps the existing **all-JSON** transport and avoids pickle's downsides (arbitrary-code-execution on unpickle, Python/lib version coupling, opaque payloads in logs, and the cross-environment community-sharing path). The key idea: a custom node is identified in the IR by a `"type"` string + JSON config and reconstructed by **name** from a shared registry — only data crosses the wire; the logic lives in shared code both agents already import.

## What changed

- **`nodes/registry.py`** *(new)* — extensible compile/validate dispatch. `register_node_type(name, compile=…, validate=…)`. The five built-ins (`sequence`/`selector`/`parallel`/`action`/`condition`) register here, and `IRExecutor._compile` / `_validate_tree` now delegate to it instead of a hard-coded `if/elif` ladder (−124 lines in `ir_executor.py`).
- **`nodes/compute_node.py`** *(new)* — `BlackboardComputeNode`, the canonical custom compute node. Its logic is a **named** op from `COMPUTE_OPS` (`all/any/not/sum/max/min`, extensible via `register_compute_op`) — never embedded code — so it serialises as pure JSON: `{type, op, inputs, output, args}`.
- **`serialization.py`** *(new)* — explicit persist/load contract: `serialize_tree` / `to_bytes` / `deserialize_tree` / `validate_tree`. Round-trip holds for any tree of registered node types.
- **`CLAUDE.md`** — "Add a new BT node type" cheat-sheet now points at `register_node_type` + the no-code-in-IR rule.

## Why no pickle / no transport change

Plans already cross ISA → UA as a JSON string in the SPADE message body. Making custom nodes JSON-representable means that **same existing path** now carries them — no message-format or byte-transport change needed.

## Testing

- `conda run -n ami pytest tests/unit -q` → **178 passed** (164 existing + 14 new).
- Existing `test_bt_schema.py` / `test_ir_executor.py` unchanged — validation/compile semantics preserved (public `IRExecutor.validate_tree` / `_compile` intact).
- New `tests/unit/test_node_registry.py`: JSON + bytes round-trip, blackboard read/write execution, unknown-type rejection, third-party node registration.

## Notes

- Targets `code_cleanup` (the active integration branch), consistent with PR #24.
- Closes #22.
